### PR TITLE
Add ignore-air-pollution flag

### DIFF
--- a/leap/agent.py
+++ b/leap/agent.py
@@ -22,6 +22,7 @@ class Agent:
             An integer representing the year of the simulation. For example, if
             the simulation starts in 2023, then the ``year_index`` for 2023 is 1, for 2024 is 2, etc.
     """
+
     def __init__(
         self,
         sex: str | int | bool | Sex,
@@ -38,7 +39,8 @@ class Agent:
         asthma_status: bool = False,
         control_levels: ControlLevels = ControlLevels(0.3333, 0.3333, 0.3333),
         exacerbation_history: ExacerbationHistory = ExacerbationHistory(0, 0),
-        exacerbation_severity_history: ExacerbationSeverityHistory = ExacerbationSeverityHistory(np.zeros(4), np.zeros(4)),
+        exacerbation_severity_history: ExacerbationSeverityHistory = ExacerbationSeverityHistory(
+            np.zeros(4), np.zeros(4)),
         total_hosp: int = 0,
         has_family_history: bool | None = None,
         family_history: FamilyHistory | None = None,
@@ -106,7 +108,7 @@ class Agent:
     def asthma_age(self) -> int | None:
         """The age at which the person was diagnosed with asthma."""
         return self._asthma_age
-    
+
     @asthma_age.setter
     def asthma_age(self, asthma_age: int | None):
         self._asthma_age = asthma_age
@@ -115,7 +117,7 @@ class Agent:
     def asthma_status(self) -> bool:
         """TODO."""
         return self._asthma_status
-    
+
     @asthma_status.setter
     def asthma_status(self, asthma_status: bool):
         self._asthma_status = asthma_status
@@ -124,7 +126,7 @@ class Agent:
     def census_division(self) -> CensusDivision:
         """The Canadian census division where the person resides."""
         return self._census_division
-    
+
     @census_division.setter
     def census_division(self, census_division: CensusDivision):
         self._census_division = census_division
@@ -132,7 +134,7 @@ class Agent:
     @property
     def control_levels(self) -> ControlLevels:
         """The control levels for the person's asthma.
-        
+
         This refers to how well the condition is managed. There are three levels of asthma control:
 
         * 1 = fully-controlled
@@ -149,14 +151,14 @@ class Agent:
     @property
     def exacerbation_history(self) -> ExacerbationHistory:
         """The asthma exacerbation history of the person.
-        
+
         The exacerbation history object contains the total number of asthma exacerbations for
         the current year (``num_current_year``) and the total number of asthma exacerbations
         for the previous year (``num_previous_year``).
 
         """
         return self._exacerbation_history
-    
+
     @exacerbation_history.setter
     def exacerbation_history(self, exacerbation_history: ExacerbationHistory):
         self._exacerbation_history = exacerbation_history
@@ -164,7 +166,7 @@ class Agent:
     @property
     def exacerbation_severity_history(self) -> ExacerbationSeverityHistory:
         """The number of asthma exacerbations by severity.
-        
+
         The exacerbation severity history object contains the number of asthma exacerbations
         by severity for the current year (``current_year``) and the number of asthma exacerbations
         by severity for the previous year (``previous_year``). There are 4 levels of severity:
@@ -173,7 +175,7 @@ class Agent:
         * 1 = moderate
         * 2 = severe
         * 3 = very severe
-        
+
         """
         return self._exacerbation_severity_history
 
@@ -196,7 +198,7 @@ class Agent:
     def has_family_history(self) -> bool:
         """Whether or not the person has a family history of asthma."""
         return self._has_family_history
-    
+
     @has_family_history.setter
     def has_family_history(self, has_family_history: bool):
         self._has_family_history = has_family_history
@@ -205,7 +207,7 @@ class Agent:
     def num_antibiotic_use(self) -> int:
         """The number of times the person has used a round of antibiotics."""
         return self._num_antibiotic_use
-    
+
     @num_antibiotic_use.setter
     def num_antibiotic_use(self, num_antibiotic_use: int):
         self._num_antibiotic_use = num_antibiotic_use
@@ -222,9 +224,9 @@ class Agent:
     @property
     def province(self) -> str:
         """The province where the person resides.
-        
+
         This is a two-letter abbreviation, e.g. ``BC`` for British Columbia:
-        
+
         * ``CA``: All of Canada
         * ``AB``: Alberta
         * ``BC``: British Columbia
@@ -242,7 +244,7 @@ class Agent:
 
         """
         return self._province
-    
+
     @province.setter
     def province(self, province: str):
         self._province = province
@@ -251,7 +253,7 @@ class Agent:
     def sex(self) -> Sex:
         """The sex of the person."""
         return self._sex
-    
+
     @sex.setter
     def sex(self, value: Sex | str | int | bool):
         if isinstance(value, Sex):
@@ -262,12 +264,12 @@ class Agent:
     @property
     def ssp(self) -> str:
         """The shared socioeconomic pathway (SSP) scenario.
-        
+
         Used for determining the pollution data in the agent's census division if the pollution
         data is not provided.
         """
         return self._ssp
-    
+
     @ssp.setter
     def ssp(self, ssp: str):
         self._ssp = ssp
@@ -289,4 +291,3 @@ class Agent:
     @uuid.setter
     def uuid(self, uuid: UUID4):
         self._uuid = uuid
-    

--- a/leap/agent.py
+++ b/leap/agent.py
@@ -82,10 +82,7 @@ class Agent:
             self.census_division = CensusDivision(province=province, year=year)
         else:
             self.census_division = census_division
-        if pollution is None:
-            self.pollution = Pollution(self.census_division.cduid, year, month, ssp)
-        else:
-            self.pollution = pollution
+        self.pollution = pollution
 
     @property
     def age(self) -> int:
@@ -214,12 +211,12 @@ class Agent:
         self._num_antibiotic_use = num_antibiotic_use
 
     @property
-    def pollution(self) -> Pollution:
+    def pollution(self) -> Pollution | None:
         """The pollution data for the person's census division."""
         return self._pollution
 
     @pollution.setter
-    def pollution(self, pollution: Pollution):
+    def pollution(self, pollution: Pollution | None):
         self._pollution = pollution
 
     @property

--- a/leap/main.py
+++ b/leap/main.py
@@ -12,7 +12,6 @@ logger = get_logger(__name__)
 pretty_printer = pprint.PrettyPrinter(indent=2, sort_dicts=False)
 
 
-
 def get_parser() -> argparse.ArgumentParser:
     """Get the command line interface parser."""
 
@@ -89,6 +88,10 @@ def get_parser() -> argparse.ArgumentParser:
         help="Print all the output."
     )
     args.add_argument(
+        "-ip", "--ignore-pollution", dest="ignore_pollution", action="store_true",
+        help="Do not include pollution as an element affecting the simulation."
+    )
+    args.add_argument(
         "-h", "--help", action="help", default=argparse.SUPPRESS,
         help="Shows function documentation."
     )
@@ -121,8 +124,6 @@ def run_main():
     if args.verbose:
         set_logging_level(20)
 
-    logger.message(f"Config:\n{pretty_printer.pformat(config)}")
-
     simulation = Simulation(
         config=config,
         max_age=args.max_age,
@@ -130,7 +131,8 @@ def run_main():
         province=args.province,
         time_horizon=args.time_horizon,
         num_births_initial=args.num_births_initial,
-        population_growth_type=args.population_growth_type
+        population_growth_type=args.population_growth_type,
+        ignore_pollution_flag=args.ignore_pollution
     )
 
     if args.run:

--- a/leap/simulation.py
+++ b/leap/simulation.py
@@ -30,6 +30,7 @@ logger = get_logger(__name__)
 class Simulation:
     """A class containing information about the simulation.
     """
+
     def __init__(
         self,
         config: dict | str | pathlib.Path | None = None,
@@ -99,7 +100,7 @@ class Simulation:
     def max_age(self) -> int:
         """The maximum age of the agents in the simulation."""
         return self._max_age
-    
+
     @max_age.setter
     def max_age(self, max_age: int):
         self._max_age = max_age
@@ -108,7 +109,7 @@ class Simulation:
     def province(self) -> str:
         """The 2-letter abbreviation of the province in the simulation."""
         return self._province
-    
+
     @province.setter
     def province(self, province: str):
         self._province = province
@@ -117,7 +118,7 @@ class Simulation:
     def min_year(self) -> int:
         """The starting year of the simulation."""
         return self._min_year
-    
+
     @min_year.setter
     def min_year(self, min_year: int):
         self._min_year = min_year
@@ -130,7 +131,7 @@ class Simulation:
     def time_horizon(self) -> int:
         """The number of years the simulation will run for."""
         return self._time_horizon
-    
+
     @time_horizon.setter
     def time_horizon(self, time_horizon: int):
         self._time_horizon = time_horizon
@@ -143,7 +144,7 @@ class Simulation:
     def num_births_initial(self) -> int:
         """The number of births in the initial year of the simulation."""
         return self._num_births_initial
-    
+
     @num_births_initial.setter
     def num_births_initial(self, num_births_initial: int):
         self._num_births_initial = num_births_initial
@@ -169,7 +170,7 @@ class Simulation:
         See `StatCan <https://www150.statcan.gc.ca/n1/pub/91-520-x/91-520-x2022001-eng.htm>`_.
         """
         return self._population_growth_type
-    
+
     @population_growth_type.setter
     def population_growth_type(self, population_growth_type: str):
         self._population_growth_type = population_growth_type
@@ -216,7 +217,7 @@ class Simulation:
 
         Returns:
             A dataframe containing a list of new agents to add to the model.
-            
+
             The dataframe has the following columns:
 
             * ``age``: The age of the agent.
@@ -257,7 +258,7 @@ class Simulation:
                 size=num_immigrants,
                 p=list(self.immigration.table.get_group((year,))["prop_immigrants_year"])
             ))
-            
+
             immigrant_df = self.immigration.table.get_group((year,)).iloc[immigrant_indices]
             sexes_immigrant = immigrant_df["sex"].tolist()
             ages_immigrant = immigrant_df["age"].tolist()
@@ -351,7 +352,10 @@ class Simulation:
         for level in range(3):
             outcome_matrix.control.increment(
                 column="prob",
-                filter_columns={"year": agent.year, "level": level, "sex": agent.sex, "age": agent.age},
+                filter_columns={"year": agent.year,
+                                "level": level,
+                                "sex": agent.sex,
+                                "age": agent.age},
                 amount=agent.control_levels.as_array()[level]
             )
 
@@ -428,11 +432,11 @@ class Simulation:
 
     def run(self, seed=None, until_all_die: bool = False):
         """Run the simulation.
-        
+
         Args:
             seed: The random seed to use for the simulation.
             until_all_die: Whether to run the simulation until all agents die.
-            
+
         Returns:
             The outcome matrix.
         """
@@ -557,7 +561,9 @@ class Simulation:
                     outcome_matrix.asthma_prevalence_contingency_table.increment(
                         column="n_asthma" if agent.has_asthma else "n_no_asthma",
                         filter_columns={
-                            "year": agent.year, "age": agent.age, "sex": agent.sex,
+                            "year": agent.year,
+                            "age": agent.age,
+                            "sex": agent.sex,
                             "fam_history": agent.has_family_history,
                             "abx_exposure": agent.num_antibiotic_use
                         }

--- a/leap/simulation.py
+++ b/leap/simulation.py
@@ -363,10 +363,12 @@ class Simulation:
         for level in range(3):
             outcome_matrix.control.increment(
                 column="prob",
-                filter_columns={"year": agent.year,
-                                "level": level,
-                                "sex": agent.sex,
-                                "age": agent.age},
+                filter_columns={
+                    "year": agent.year,
+                    "level": level,
+                    "sex": agent.sex,
+                    "age": agent.age
+                },
                 amount=agent.control_levels.as_array()[level]
             )
 

--- a/leap/simulation.py
+++ b/leap/simulation.py
@@ -96,6 +96,17 @@ class Simulation:
         self.SSP = config["pollution"]["SSP"]
         self.outcome_matrix = None
 
+    def __repr__(self):
+        return (
+            f"Simulation("
+            f"max_age={self.max_age}, "
+            f"province='{self.province}', "
+            f"min_year={self.min_year}, "
+            f"time_horizon={self.time_horizon}, "
+            f"num_births_initial={self.num_births_initial}, "
+            f"population_growth_type='{self.population_growth_type}')"
+        )
+
     @property
     def max_age(self) -> int:
         """The maximum age of the agents in the simulation."""

--- a/leap/simulation.py
+++ b/leap/simulation.py
@@ -38,7 +38,8 @@ class Simulation:
         min_year: int | None = None,
         time_horizon: int | None = None,
         num_births_initial: int | None = None,
-        population_growth_type: str | None = None
+        population_growth_type: str | None = None,
+        ignore_pollution_flag: bool = False
     ):
         if config is None:
             with open(get_data_path("processed_data/config.json")) as file:
@@ -89,6 +90,7 @@ class Simulation:
         self.utility = Utility(config["utility"])
         self.cost = AsthmaCost(config["cost"])
         self.census_table = CensusTable(config["census_table"])
+        self.ignore_pollution_flag = ignore_pollution_flag
         self.pollution_table = PollutionTable()
         self.SSP = config["pollution"]["SSP"]
         self.outcome_matrix = None
@@ -471,10 +473,16 @@ class Simulation:
                 census_division = CensusDivision(
                     census_table=self.census_table, province=self.province
                 )
-                pollution = Pollution(
-                    pollution_table=self.pollution_table, SSP=self.SSP, year=year, month=month,
-                    cduid=census_division.cduid
-                )
+                if self.ignore_pollution_flag:
+                    pollution = None
+                else:
+                    pollution = Pollution(
+                        pollution_table=self.pollution_table,
+                        SSP=self.SSP,
+                        year=year,
+                        month=month,
+                        cduid=census_division.cduid
+                    )
                 agent = Agent(
                     sex=new_agents_df["sex"].iloc[i],
                     age=new_agents_df["age"].iloc[i],


### PR DESCRIPTION
## Description

This PR introduces a new flag (`--ignore-pollution`) that allows users to run the asthma model without considering the effects of air pollution. By default, the model still includes air pollution effects, but setting this flag to True will exclude them from calculations.

You can track revisions and file progression through the commits in https://github.com/resplab/leap/pull/17


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] test_workflow
- [x] test_workflow_lfs

## Linked PRs / Issues

List here any related pull requests (from this repo or other repos) and/or the issue this PR is addressing.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [ ] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
