### PR TITLE
change pybtex dependency

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,6 @@
 docutils==0.18.1
 sphinx==7.0.0
+pybtex==0.24.0
 sphinxcontrib-bibtex==2.4.2
 sphinx-rtd-theme==2.0.0
 myst-parser==3.0.0


### PR DESCRIPTION
## Description

One of the dependencies of `sphinxcontrib.bibtex` is `pybtex`. This was updated on 21 June 2025 to Version `0.25.0`:

https://docs.pybtex.org/history.html

which is now failing with the error:

```sh
Extension error:
Could not import extension sphinxcontrib.bibtex (exception: cannot import name '_FakeEntryPoint' from 'pybtex.plugin' 
```

Rolling this back to `pybtex == 0.24.0` fixes the issue. 

Issue opened on `pybtex`:
https://bitbucket.org/pybtex-devs/pybtex/issues/458/error-cannot-import-name-_fakeentrypoint



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [ ] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
