### PR TITLE
Fix `__lte__` bug, add `__gt__`, `__ge__`

### DIFF
--- a/leap/utils.py
+++ b/leap/utils.py
@@ -662,6 +662,29 @@ class TimeDelta(relativedelta):
         else:
             raise TypeError(f"Unsupported type for comparison: {type(other)}")
         
+    def __gt__(self, other: TimeDelta | dt.timedelta | relativedelta) -> bool:
+        if isinstance(other, dt.timedelta) or isinstance(other, TimeDelta):
+            return self.total_seconds() > other.total_seconds()
+        elif isinstance(other, relativedelta):
+            total_seconds = (
+                other.years * 365 * 24 * 3600 + 
+                other.months * 30 * 24 * 3600 + 
+                other.days * 24 * 3600 + 
+                other.hours * 3600 + 
+                other.minutes * 60 + 
+                other.seconds + 
+                other.microseconds / 1e6
+            )
+            return self.total_seconds() > total_seconds
+        else:
+            raise TypeError(f"Unsupported type for comparison: {type(other)}")
+        
+    def __ge__(self, other: TimeDelta | dt.timedelta | relativedelta) -> bool:
+        if isinstance(other, dt.timedelta) or isinstance(other, TimeDelta) or isinstance(other, relativedelta):
+            return self.__gt__(other) or self.__eq__(other)
+        else:
+            raise TypeError(f"Unsupported type for comparison: {type(other)}")
+        
     def __str__(self) -> str:
         return self.to_isoformat()
     

--- a/leap/utils.py
+++ b/leap/utils.py
@@ -656,7 +656,7 @@ class TimeDelta(relativedelta):
         else:
             raise TypeError(f"Unsupported type for comparison: {type(other)}")
         
-    def __lte__(self, other: TimeDelta | dt.timedelta | relativedelta) -> bool:
+    def __le__(self, other: TimeDelta | dt.timedelta | relativedelta) -> bool:
         if isinstance(other, dt.timedelta) or isinstance(other, TimeDelta) or isinstance(other, relativedelta):
             return self.__lt__(other) or self.__eq__(other)
         else:


### PR DESCRIPTION
## Description

The `TimeDelta` class had a mistake in naming the less than or equal to function `__lte__` instead of `__le__`. I have fixed this and also added the missing `__gt__` and `__ge__` functions to the class.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Linked PRs / Issues

List here any related pull requests (from this repo or other repos) and/or the issue this PR is addressing.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [ ] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
