### PR TITLE
Modify `get_data_path` to create directories if not found

### DIFF
--- a/leap/utils.py
+++ b/leap/utils.py
@@ -187,11 +187,12 @@ def compute_ordinal_regression(
     return [float(prob_function(θ[k + 1] - η) - prob_function(θ[k] - η)) for k in range(len(θ) - 1)]
 
 
-def get_data_path(data_path: str | pathlib.Path) -> pathlib.Path:
+def get_data_path(data_path: str | pathlib.Path, mkdirs: bool = False) -> pathlib.Path:
     """Get the full path to a data file or folder in the ``LEAP`` package.
 
     Args:
         data_path: The path to the file or folder.
+        mkdirs: Whether to create the directories if they don't exist.
 
     Returns:
         The full path to the file or folder.
@@ -210,13 +211,19 @@ def get_data_path(data_path: str | pathlib.Path) -> pathlib.Path:
     elif data_path.parts[0] == "original_data":
         data_path = data_path.relative_to("original_data")
         data_folder = "leap.original_data"
+    else:
+        raise FileNotFoundError(f"Path {data_path} not found.")
   
     package_path = str(pkg_resources.files(data_folder).joinpath(str(data_path)))
 
     if os.path.isfile(package_path) or os.path.isdir(package_path):
         return pathlib.Path(package_path)
     else:
-        raise FileNotFoundError(f"Path {data_path} not found.")
+        if mkdirs:
+            os.makedirs(os.path.dirname(package_path), exist_ok=True)
+            return pathlib.Path(package_path)
+        else:
+            raise FileNotFoundError(f"Path {data_path} not found.")
 
 
 def check_file(file_path: str | pathlib.Path, ext: str):


### PR DESCRIPTION
## Description

The purpose of `get_data_path` is two-fold:

1. To make sure that the path to package data does not depend on how `LEAP` was installed
2. To allow the use of a shorthand for the various data folders

One of the downsides currently is that if you want to get the proper path for a file that has not yet been created, it fails with a `FileNotFoundError`. In this PR, I have added a `mkdirs` argument to allow the directories to be created if they do not exist.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have documented my code with appropriate docstrings
- [ ] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
