### PR TITLE
Fix LFS Issues

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+  fetchexclude = *

--- a/docs/dev/dev-installation.rst
+++ b/docs/dev/dev-installation.rst
@@ -112,3 +112,14 @@ To install a development version of the ``LEAP`` package:
   pip install -e ".[dev]"
   pip install -r requirements-docs.txt
   pip install -r requirements-data-generation.txt
+
+
+If you will be working on the ``data_generation`` code, then you will need the ``Git LFS`` 
+files. By default, we have set ``git clone`` to ignore the ``Git LFS`` files in order to keep
+the ``Git LFS`` bandwidth usage down. To download these large files, you will need to run the
+following command:
+
+.. code:: bash
+
+  cd leap
+  git lfs pull -X ""


### PR DESCRIPTION
## Description

To address this issues with hitting the LFS bandwidth:

1. I have added a `.lfsconfig` file which changes the `git clone` settings so that users will not download LFS files by default when they run `git clone <leap>`.
2. I have made sure the repo settings do not include Git LFS objects if you download the zip file of the repo. See this section: [GitHub Docs: Archives](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-git-lfs-objects-in-archives-of-your-repository)
<img width="842" height="232" alt="Screenshot 2026-06-17 at 12 10 14" src="https://github.com/user-attachments/assets/afdd0c28-2e95-48cd-af08-cd332512eb3b" />



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

1. On my computer, I ran the following check:

```sh
git clone -b clone-lfs --single-branch https://github.com/resplab/leap.git
```

As expected, this downloaded the `LEAP` repo but did not download the LFS files. 

2. On my computer, I checked to make sure that developers could download LFS files if necessary:

```sh
cd leap
git lfs pull -X ""
```
As expected, this threw the following error:

```
batch response: This repository exceeded its LFS budget. The account responsible for the budget should increase it to restore access.                                           
Failed to fetch some objects from 'https://github.com/resplab/leap.git/info/lfs'
```

Given that we have hit our LFS bandwidth limit, this was the expected response - the code was fetching the files for download, but it was blocked by our quota. Once our quota resets, this should therefore work.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
