### PR TITLE
Add family history model documentation

### DIFF
--- a/docs/model/index.rst
+++ b/docs/model/index.rst
@@ -15,6 +15,7 @@ outcomes over a lifetime.
   model-death
   model-migration
   model-antibiotics
+  model-family-history
   model-occurrence
   model-control
   model-exacerbation

--- a/docs/model/model-family-history.rst
+++ b/docs/model/model-family-history.rst
@@ -1,0 +1,73 @@
+.. _family-history-model:
+
+========================
+Family History Model
+========================
+
+Family history of asthma is a binary risk factor assigned to each agent at birth. It represents
+whether at least one parent of the agent has asthma, and it affects the agent's probability of
+developing asthma throughout their simulated life via the
+:ref:`Asthma Occurrence Model <occurrence-model>`.
+
+Data
+====
+
+The family history model is derived from an original analysis of the
+`CHILD Cohort Study <https://childcohort.ca/>`_, a prospective cohort study of Canadian children. Two quantities are taken from this study:
+
+1. **The prevalence of parental asthma** — the probability that a newborn agent has at least
+   one parent with asthma. This is used to assign family history status at birth.
+2. **Age-dependent odds ratios** — the relationship between family history and asthma risk
+   at ages 3 and 5, used to parameterise both the prevalence and incidence risk factor
+   corrections in the :ref:`Occurrence Model <occurrence-model-2>`.
+
+The ``CHILD`` study cohort data is not open to the public. One can obtain access by following
+the instructions on the `CHILD Cohort Study website <https://childstudy.ca/for-researchers/data-access/>`_.
+
+Model: Bernoulli Distribution
+==============================
+
+At birth, each simulated agent is assigned a family history status by drawing from a
+``Bernoulli distribution``:
+
+.. math::
+
+   f_i \sim \text{Bernoulli}(p)
+
+where:
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Variable
+     - Domain
+     - Description
+   * - :math:`f_i`
+     - :math:`\{0, 1\}`
+     - family history status of agent :math:`i`; ``1`` = at least one parent has asthma,
+       ``0`` = neither parent has asthma
+   * - :math:`p`
+     - probability :math:`\in [0, 1]`
+     - probability that a newborn agent has a family history of asthma
+
+The parameter :math:`p` is estimated from the ``CHILD Cohort Study`` as the overall (unadjusted) proportion of
+enrolled families in which at least one parent had an asthma diagnosis:
+
+.. math::
+
+   p = 0.2927
+
+Family history status is fixed at birth and does not change over the agent's simulated
+lifetime.
+
+Role in the Occurrence Model
+==============================
+
+Once assigned, :math:`f_i` is used as a risk factor in the
+:ref:`Asthma Occurrence Model <occurrence-model-2>`. The CHILD Study also provides the two
+empirical odds ratios that anchor the age-dependent log-OR formula used there —
+OR = 1.13 at age 3 and OR = 2.40 at age 5 :cite:`patrick2020`. See
+:ref:`occurrence-model-2` for the full derivation of how these ORs are converted into
+log-OR coefficients and combined with the antibiotic exposure log-OR and calibration
+term :math:`\alpha` to produce each agent's individual asthma probability.

--- a/docs/model/model-occurrence.rst
+++ b/docs/model/model-occurrence.rst
@@ -768,8 +768,9 @@ Family History
 ~~~~~~~~~~~~~~~~
 
 The family history log-OR was derived from the ``CHILD Study`` by Patrick et al.
-:cite:`patrick2020` using logistic regression. It applies to all ages but the age-dependent
-component plateaus at age 5:
+:cite:`patrick2020` using logistic regression. See :ref:`family-history-model` for how the
+family history risk factor is assigned to agents and how :math:`p = 0.2927` is estimated from
+the same study. The log-OR applies to all ages but the age-dependent component plateaus at age 5:
 
 .. math::
 

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -267,7 +267,8 @@ To initialize an agent, we set the following initial attributes:
    * - family history of asthma
      - Assigned via a Bernoulli draw using the population prevalence of parental asthma.
        1 = at least one parent has asthma, 0 = neither parent has asthma.
-       See :ref:`occurrence-model-2` for how this enters the asthma probability.
+       See :ref:`family-history-model` for details on the assignment process, and
+       :ref:`occurrence-model-2` for how this affects the asthma probability.
    * - antibiotic exposure in infancy
      - The number of courses of antibiotics taken during the first year of life, drawn from a
        negative binomial distribution. Values are capped at 3 for the purposes of odds ratio


### PR DESCRIPTION
## Description

Adds a new documentation page for the Family History risk factor (`docs/model/model-family-history.rst`). Previously, family history was only briefly mentioned as a risk factor in the Occurrence Model page with no dedicated explanation of how it is assigned to agents.

The new page covers:
- The CHILD Cohort Study as the data source
- The Bernoulli distribution used to assign family history status at birth (`p = 0.2927`)
- The two anchor odds ratios from the CHILD Study (OR = 1.13 at age 3, OR = 2.40 at age 5) with a cross-reference to the Occurrence Model for the full derivation

Cross-references were also added to the Occurrence Model and Simulation pages to point to the new page where appropriate. The family history OR formula and coefficient table that were duplicated in the new page have been removed — the Occurrence Model page remains the single source for the calibration derivation.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

No code changes — documentation only. Verified RST structure parses without errors.

- [ ] Test A
- [ ] Test B

## Linked PRs / Issues

N/A

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

