### PR TITLE
Update asthma control documentation

### DIFF
--- a/docs/model/model-control.rst
+++ b/docs/model/model-control.rst
@@ -20,10 +20,10 @@ We followed the
 to define asthma control level by using the sum of the
 four indicator variables (0 if no and 1 if yes) in the last 4 weeks before each measurement:
 
-1. Daytime symptoms more than twice per week?
-2. Any night waking due to asthma symptoms?
-3. Reliever medication needed more than twice per week?
-4. Any activity limitation due to asthma?
+1. **daytime symptoms**: Daytime symptoms more than twice per week?
+2. **nocturnal symptoms**: Any night waking due to asthma symptoms?
+3. **inhaler use**: Reliever medication needed more than twice per week?
+4. **limited activities**: Any activity limitation due to asthma?
 
 Responses of *do not know* were treated as *no*. Five patients were excluded due to missing or
 implausible asthma diagnosis dates (two with diagnosis dates predating birth, three with no

--- a/docs/model/model-control.rst
+++ b/docs/model/model-control.rst
@@ -348,11 +348,11 @@ The model is:
 .. math::
 
   \text{logit}(P(y^{(i)} \leq k)) = \theta_k
-    + \beta_{\text{age}} \cdot a_i
-    + \beta_{\text{sex}} \cdot s_i
-    + \beta_{\text{age}^2} \cdot a_i^2
-    + \beta_{\text{age,sex}} \cdot a_i \cdot s_i
-    + \beta_{\text{age}^2\text{,sex}} \cdot a_i^2 \cdot s_i
+    + \beta_{\text{age}} \cdot a^{(i)}
+    + \beta_{\text{sex}} \cdot s^{(i)}
+    + \beta_{\text{age}^2} \cdot {a^{(i)}}^2
+    + \beta_{\text{age,sex}} \cdot a^{(i)} \cdot s^{(i)}
+    + \beta_{\text{age}^2\text{,sex}} \cdot {a^{(i)}}^2 \cdot s^{(i)}
     + \beta_0^{(i)}
 
 where:
@@ -371,30 +371,30 @@ where:
      - level-specific threshold (2 thresholds for 3 control levels)
    * - :math:`\beta_{\text{age}}`
      -
-     - :math:`a_i`
+     - :math:`a^{(i)}`
      - age main effect
    * - :math:`\beta_{\text{sex}}`
      -
-     - :math:`s_i`
+     - :math:`s^{(i)}`
      - sex main effect
    * - :math:`\beta_{\text{age}^2}`
      -
-     - :math:`a_i^2`
+     - :math:`{a^{(i)}}^2`
      - age quadratic term
    * - :math:`\beta_{\text{age,sex}}`
      -
-     - :math:`a_i \cdot s_i`
+     - :math:`a^{(i)} \cdot s^{(i)}`
      - age × sex interaction
    * - :math:`\beta_{\text{age}^2\text{,sex}}`
      -
-     - :math:`a_i^2 \cdot s_i`
+     - :math:`{a^{(i)}}^2 \cdot s^{(i)}`
      - age² × sex interaction
    * - :math:`\beta_0^{(i)}`
      -
      -
      - patient-specific random effect; :math:`\beta_0^{(i)} \sim \mathcal{N}(0, \sigma^2)`
 
-and :math:`y^{(i)}` is the observed control level, :math:`k \in \{1, 2, 3\}` is the control level index, :math:`a_i` is the age, and :math:`s_i` is the sex of patient :math:`i`.
+and :math:`y^{(i)}` is the observed control level, :math:`k \in \{1, 2, 3\}` is the control level index, :math:`a^{(i)}` is the age, and :math:`s^{(i)}` is the sex of patient :math:`i`.
 
 The probability of being in a specific control level is:
 

--- a/docs/model/model-control.rst
+++ b/docs/model/model-control.rst
@@ -340,7 +340,7 @@ Model: Ordinal Regression with Random Effects
 =============================================
 
 We use an ``ordinal regression`` model with a patient-specific ``random effect`` to predict
-asthma control level from age and sex. See :doc:`model-statistical-background` for background
+asthma control level from age and sex. See :ref:`ordinal-regression` for background
 on ordinal regression and random effects.
 
 The model is:

--- a/docs/model/model-control.rst
+++ b/docs/model/model-control.rst
@@ -394,7 +394,8 @@ where:
      -
      - patient-specific random effect; :math:`\beta_0^{(i)} \sim \mathcal{N}(0, \sigma^2)`
 
-and :math:`y^{(i)}` is the observed control level, :math:`k \in \{1, 2, 3\}` is the control level index, :math:`a^{(i)}` is the age, and :math:`s^{(i)}` is the sex of patient :math:`i`.
+and :math:`y^{(i)}` is the observed control level, :math:`k \in \{1, 2, 3\}` is the control level
+index, :math:`a^{(i)}` is the age, and :math:`s^{(i)}` is the sex of patient :math:`i`.
 
 The probability of being in a specific control level is:
 

--- a/docs/model/model-control.rst
+++ b/docs/model/model-control.rst
@@ -7,32 +7,27 @@ Asthma Control Model
 Data
 ====
 
-Raw Data
+Economic Burden of Asthma (EBA) Study
 ***********
 
-``EBA``	was	a	prospective representative observational study of 618 participants aged 1-85
-years (74% were >= 18 years old) with self-reported, physician-diagnosed asthma from BC.
-The measurements were taken every 3 months for a year. Among 613 patients, only 6% were lost
-during the one-year follow-up. There were at least 500 cases for each asthma control level.
-More females were in the cohort as expected (adult asthma is more prevalent among females).
-Asthma control level changed during the follow-up for 79% of the patients.
+``EBA`` was a prospective observational study of 618 participants (aged 1–85; 74% adults)
+with self-reported, physician-diagnosed asthma from BC, with measurements taken every 3 months
+for a year. Only 6% of the 613 patients were lost to follow-up, and asthma control level
+changed during follow-up for 79% of patients.
 
 We followed the 
 `2020 GINA guidelines <https://ginasthma.org/wp-content/uploads/2020/04/GINA-2020-full-report_-final-_wms.pdf>`_
 to define asthma control level by using the sum of the
-four indicator variables (0 if no and 1 if yes) in the last 3 months before each measurement:
+four indicator variables (0 if no and 1 if yes) in the last 4 weeks before each measurement:
 
-1. daily symptoms
-2. nocturnal symptoms
-3. inhaler use
-4. limited activities
+1. Daytime symptoms more than twice per week?
+2. Any night waking due to asthma symptoms?
+3. Reliever medication needed more than twice per week?
+4. Any activity limitation due to asthma?
 
-If the sum is zero, then the asthma control level is controlled. If it is less than 3, then it is
-partially-controlled. Otherwise, it is uncontrolled. For responses with *do not know* to the
-indicator variables, we treated them as a *no*. In this analysis, we did not consider treatment
-nor whether a patient experienced an exacerbation in the last 3 months before the visit.
-We excluded two patients whose asthma diagnosis dates were earlier than they were born and three
-patients who had no asthma diagnosis dates, for a final count of 613 patients.
+Responses of *do not know* were treated as *no*. Five patients were excluded due to missing or
+implausible asthma diagnosis dates (two with diagnosis dates predating birth, three with no
+diagnosis date), for a final count of 613 patients.
 
 .. raw:: html
 
@@ -164,12 +159,8 @@ patients who had no asthma diagnosis dates, for a final count of 613 patients.
 Processed Data
 ***************
 
-In keeping with ``Python`` conventions, the columns were converted to snake case. In addition,
-``studyId`` was renamed to ``patient_id``, as ``studyId`` indicates that the ID is for a given
-study, when in fact the ID was for an individual patient.
-
-The variables ``daytimeSymptoms``, ``nocturnalSymptoms``, ``inhalerUse``, and ``limitedActivities``
-were converted to binary variables, where ``1 = True`` and ``0 = False``.
+Columns were converted to snake case and ``studyId`` was renamed to ``patient_id``. The four
+GINA indicator variables were binarized (``1 = True``, ``0 = False``).
 
 We also needed to compute the asthma control level from the four indicator variables. We first
 computed the ``control_score``, defined as:
@@ -345,105 +336,90 @@ Then we defined the asthma control level as follows:
     </tbody>
   </table>
 
-Model
-=====
+Model: Ordinal Regression with Random Effects
+=============================================
 
-Our goal is to fit a model for generating the proportion of time that an individual labelled as
-``asthmatic`` spends in each control level.
+We use an ``ordinal regression`` model with a patient-specific ``random effect`` to predict
+asthma control level from age and sex. See :doc:`model-statistical-background` for background
+on ordinal regression and random effects.
 
-Ordinal Regression
-******************
-
-``Ordinal regression`` is a type of regression analysis that is used when the response variable
-(in our case, the control level) is ordered, but the intervals between the levels are
-arbitrary. In our case, the order of the control levels matters
-(``controlled`` < ``partially-controlled`` < ``uncontrolled``), but the numbers assigned to them
-and the distance between those numbers are arbitrary.
-
-To begin, we define our variables:
-
-* :math:`i`: the patient index
-* :math:`k`: the asthma control level, where :math:`k \in \{1,2,3\}`
-* :math:`y^{(i)}`: the asthma control level for patient :math:`i`, where :math:`y^{(i)} \in \{1,2,3\}`
-* :math:`\theta_k`: the threshold parameter for the :math:`k^{th}` control level
-* :math:`x_n^{(i)}`: the :math:`n^{th}` covariate for patient :math:`i`
-* :math:`\beta_n`: the coefficient for the :math:`n^{th}` covariate
-
-Then the model is:
+The model is:
 
 .. math::
 
-  \begin{align}
-    P(y^{(i)} \leq k) = \sigma(\theta_k + \sum_{n=1}^{N} \beta_n x_n^{(i)})
-  \end{align}
+  \text{logit}(P(y^{(i)} \leq k)) = \theta_k
+    + \beta_{\text{age}} \cdot a_i
+    + \beta_{\text{sex}} \cdot s_i
+    + \beta_{\text{age}^2} \cdot a_i^2
+    + \beta_{\text{age,sex}} \cdot a_i \cdot s_i
+    + \beta_{\text{age}^2\text{,sex}} \cdot a_i^2 \cdot s_i
+    + \beta_0^{(i)}
 
-where :math:`\sigma` is the logistic function:
+where:
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+
+   * - Coefficient
+     - Indices
+     - Term
+     - Description
+   * - :math:`\theta_k`
+     - :math:`k \in \{1, 2\}`
+     -
+     - level-specific threshold (2 thresholds for 3 control levels)
+   * - :math:`\beta_{\text{age}}`
+     -
+     - :math:`a_i`
+     - age main effect
+   * - :math:`\beta_{\text{sex}}`
+     -
+     - :math:`s_i`
+     - sex main effect
+   * - :math:`\beta_{\text{age}^2}`
+     -
+     - :math:`a_i^2`
+     - age quadratic term
+   * - :math:`\beta_{\text{age,sex}}`
+     -
+     - :math:`a_i \cdot s_i`
+     - age × sex interaction
+   * - :math:`\beta_{\text{age}^2\text{,sex}}`
+     -
+     - :math:`a_i^2 \cdot s_i`
+     - age² × sex interaction
+   * - :math:`\beta_0^{(i)}`
+     -
+     -
+     - patient-specific random effect; :math:`\beta_0^{(i)} \sim \mathcal{N}(0, \sigma^2)`
+
+and :math:`y^{(i)}` is the observed control level, :math:`k \in \{1, 2, 3\}` is the control level index, :math:`a_i` is the age, and :math:`s_i` is the sex of patient :math:`i`.
+
+The probability of being in a specific control level is:
 
 .. math::
 
-  \begin{align}
-    \sigma(x) = \dfrac{1}{1 + e^{-x}}
-  \end{align}
-
-and the covariates are:
-
-.. math::
-
-  \sum_{n=1}^{N} \beta_n x_n := 
-    \beta_{\text{age}} \cdot \text{age} +
-    \beta_{\text{sex}} \cdot \text{sex} +
-    \beta_{\text{age2}} \cdot \text{age}^2 +
-    \beta_{\text{sexage}} \cdot \text{sex} \cdot \text{age} +
-    \beta_{\text{sexage2}} \cdot \text{sex} \cdot \text{age}^2
-
-To obtain the probability that a patient is in a specific control level, we use the following:
-
-.. math::
-
-  \begin{align}
-    P(y^{(i)} = k) = P(y^{(i)} \leq k) - P(y^{(i)} \leq k-1)
-  \end{align}
-
-
-Random Effects
-*****************
-
-In our model, we also include a random effect to account for the correlation between
-measurements from the same patient. This is important because the measurements are taken
-repeatedly over time, and we expect that the measurements from the same patient will be more
-similar to each other than to measurements from different patients. The random effect is
-assumed to be normally distributed with mean zero and variance :math:`\sigma^2`.
-The model with random effects is:
-
-.. math::
-
-  \begin{align}
-    P(y^{(i)} \leq k) = \sigma(\theta_k + \sum_{n=1}^{N} \beta_n x_n^{(i)} + \beta_0^{(i)})
-  \end{align}
-
-where :math:`\beta_0^{(i)}` is the random effect for patient :math:`i`.
+  P(y^{(i)} = k) = P(y^{(i)} \leq k) - P(y^{(i)} \leq k-1)
 
 Fitting the Model with EBA Data
 *******************************
 
-The predictions from this model are the probabilities of being in each of the
-control levels during the 3-month period, but we make the following assumptions to allow us to
-apply these predictions to our simulation:
+The model was fit on 3-month measurement intervals. We make the following assumptions to
+apply its predictions to the simulation:
 
-1. We assume that the probability of being in each of the control levels is equivalent to the
-   proportion of time spent in each of the control levels.
-2. We assume that we may extend these predictions from a 3-month period to a 1-year period
-   (this is the time cycle of the simulation).
-3. We assume that the probability of being in a control level does not depend on time.
-4. We assume that the probability of being in a control level does not depend on the past history
-   of asthma control.
-5. We assume that the probability of being in a control level does not depend on the past history
-   of exacerbations.
+1. The probability of being in a control level is equivalent to the proportion of time
+   spent in that control level.
+2. Predictions generalise from the 3-month EBA measurement period to the simulation's
+   time interval (1 month or 1 year).
+3. Control level probabilities do not vary with calendar year.
+4. Control level probabilities do not depend on past control history.
+5. Control level probabilities do not depend on past exacerbation history.
 
-In short, for each virtual individual (agent) labelled as asthmatic, we sampled an
-individual-specific intercept from the estimated distribution of the random effects, and with that
-intercept in the asthma control prediction model, we simulated the proportion of time spent in each
-of the control levels in each time cycle.
+For each agent with asthma, an individual-specific intercept is sampled from the estimated
+random-effects distribution and held fixed for their simulated lifetime. At each time interval,
+this intercept is used with the fitted model to generate the proportion of time spent in each
+control level.
 
 
 Predictions
@@ -452,14 +428,4 @@ Predictions
 Once the ordinal regression model has been fit on the ``EBA`` dataset, the coefficients are
 saved to the ``leap/processed_data/config.json`` file. During the simulation, these coefficients
 are used to determine the probability of being in each of the control levels for each agent
-labelled as ``asthmatic``. 
-
-.. math::
-
-  \begin{align}
-    P(y^{(i)} \leq k) = \sigma(\theta_k + \sum_{n=1}^{N} \beta_n x_n^{(i)} + \beta_0^{(i)})
-  \end{align}
-
-where :math:`\beta_0^{(i)}` is assigned to each agent at the beginning of the simulation,
-sampled randomly from a normal distribution with :math:`\mu = 0` and :math:`\sigma` as
-calculated when the model was fit.
+labelled as having asthma.

--- a/docs/model/model-control.rst
+++ b/docs/model/model-control.rst
@@ -177,9 +177,9 @@ Then we defined the asthma control level as follows:
 .. math::
 
   \text{control_level} = \begin{cases}
-    1 & \text{control_score} = 0 \\
-    2 &  0 ~ < \text{control_score} < 3 \\
-    3 & \text{control_score} \geq 3
+    1 & \quad \text{control_score} = 0 \\
+    2 &  \quad 0 ~ < \text{control_score} < 3 \\
+    3 & \quad \text{control_score} \geq 3
   \end{cases}
 
 
@@ -384,11 +384,11 @@ where:
    * - :math:`\beta_{\text{age,sex}}`
      -
      - :math:`a^{(i)} \cdot s^{(i)}`
-     - age × sex interaction
+     - :math:`\text{age} \times \text{sex}` interaction
    * - :math:`\beta_{\text{age}^2\text{,sex}}`
      -
      - :math:`{a^{(i)}}^2 \cdot s^{(i)}`
-     - age² × sex interaction
+     - :math:`\text{age}^2 \times \text{sex}` interaction
    * - :math:`\beta_0^{(i)}`
      -
      -

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -335,11 +335,11 @@ probability of the agent having fully-controlled, partially-controlled, or uncon
 .. math::
 
     \text{logit}(P(y^{(i)} \leq k)) = \theta_k
-        + \beta_{\text{age}} \cdot a_i
-        + \beta_{\text{sex}} \cdot s_i
-        + \beta_{\text{age}^2} \cdot a_i^2
-        + \beta_{\text{age,sex}} \cdot a_i \cdot s_i
-        + \beta_{\text{age}^2\text{,sex}} \cdot a_i^2 \cdot s_i
+        + \beta_{\text{age}} \cdot a^{(i)}
+        + \beta_{\text{sex}} \cdot s^{(i)}
+        + \beta_{\text{age}^2} \cdot {a^{(i)}}^2
+        + \beta_{\text{age,sex}} \cdot a^{(i)} \cdot s^{(i)}
+        + \beta_{\text{age}^2\text{,sex}} \cdot {a^{(i)}}^2 \cdot s^{(i)}
         + \beta_0^{(i)}
 
 .. math::
@@ -486,11 +486,11 @@ partially-controlled, or uncontrolled asthma
 .. math::
 
     \text{logit}(P(y^{(i)} \leq k)) = \theta_k
-        + \beta_{\text{age}} \cdot a_i
-        + \beta_{\text{sex}} \cdot s_i
-        + \beta_{\text{age}^2} \cdot a_i^2
-        + \beta_{\text{age,sex}} \cdot a_i \cdot s_i
-        + \beta_{\text{age}^2\text{,sex}} \cdot a_i^2 \cdot s_i
+        + \beta_{\text{age}} \cdot a^{(i)}
+        + \beta_{\text{sex}} \cdot s^{(i)}
+        + \beta_{\text{age}^2} \cdot {a^{(i)}}^2
+        + \beta_{\text{age,sex}} \cdot a^{(i)} \cdot s^{(i)}
+        + \beta_{\text{age}^2\text{,sex}} \cdot {a^{(i)}}^2 \cdot s^{(i)}
         + \beta_0^{(i)}
 
 .. math::

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -329,34 +329,22 @@ Step 5: Determine asthma control levels
 -----------------------------------------
 
 We next determine the asthma control levels for the agent. The asthma control levels give the
-probability of the agent having fully-controlled, partially-controlled, or uncontrolled asthma:
+probability of the agent having fully-controlled, partially-controlled, or uncontrolled asthma
+(:math:`k = 1, 2, 3` respectively). The probabilities are given by the :ref:`control-model`:
 
 .. math::
 
-    k &= 0: \text{fully-controlled asthma} \\
-    k &= 1: \text{partially-controlled asthma} \\
-    k &= 2: \text{uncontrolled asthma}
-
-
-The probabilities of each control level are given by ordinal regression, where y = control level:
-
-.. math::
-
-    P(y \leq k) &= \sigma(\theta_k - \eta) \\
-    P(y = k) &= P(y \leq k) - P(y < k + 1) \\
-              &= \sigma(\theta_k - \eta) - \sigma(\theta_{k+1} - \eta)
-
-
-where:
+    \text{logit}(P(y^{(i)} \leq k)) = \theta_k
+        + \beta_{\text{age}} \cdot a_i
+        + \beta_{\text{sex}} \cdot s_i
+        + \beta_{\text{age}^2} \cdot a_i^2
+        + \beta_{\text{age,sex}} \cdot a_i \cdot s_i
+        + \beta_{\text{age}^2\text{,sex}} \cdot a_i^2 \cdot s_i
+        + \beta_0^{(i)}
 
 .. math::
 
-    \eta = \beta_0 + 
-        \text{age} \cdot \beta_{\text{age}} + 
-        \text{sex} \cdot \beta_{\text{sex}} +
-        \text{age} \cdot \text{sex} \cdot \beta_{\text{sexage}} + 
-        \text{age}^2 \cdot \text{sex} \cdot \beta_{\text{sexage}^2} + 
-        \text{age}^2 \cdot \beta_{\text{age}^2}
+    P(y^{(i)} = k) = P(y^{(i)} \leq k) - P(y^{(i)} \leq k-1)
 
 
 Step 6: Compute the number of asthma exacerbations in the current timepoint
@@ -492,34 +480,22 @@ Step 3: Compute the control levels
 
 We next determine the asthma control levels for the agent using the :ref:`control-model`.
 The asthma control levels give the probability of the agent having fully-controlled,
-partially-controlled, or uncontrolled asthma:
+partially-controlled, or uncontrolled asthma
+(:math:`k = 1, 2, 3` respectively). The probabilities are given by the :ref:`control-model`:
 
 .. math::
 
-    k &= 0: \text{fully-controlled asthma} \\
-    k &= 1: \text{partially-controlled asthma} \\
-    k &= 2: \text{uncontrolled asthma}
-
-
-The probabilities of each control level are given by ordinal regression, where y = control level:
-
-.. math::
-
-    P(y \leq k) &= \sigma(\theta_k - \eta) \\
-    P(y = k) &= P(y \leq k) - P(y < k + 1) \\
-              &= \sigma(\theta_k - \eta) - \sigma(\theta_{k+1} - \eta)
-
-
-where:
+    \text{logit}(P(y^{(i)} \leq k)) = \theta_k
+        + \beta_{\text{age}} \cdot a_i
+        + \beta_{\text{sex}} \cdot s_i
+        + \beta_{\text{age}^2} \cdot a_i^2
+        + \beta_{\text{age,sex}} \cdot a_i \cdot s_i
+        + \beta_{\text{age}^2\text{,sex}} \cdot a_i^2 \cdot s_i
+        + \beta_0^{(i)}
 
 .. math::
 
-    \eta = \beta_0 + 
-        \text{age} \cdot \beta_{\text{age}} + 
-        \text{sex} \cdot \beta_{\text{sex}} +
-        \text{age} \cdot \text{sex} \cdot \beta_{\text{sexage}} + 
-        \text{age}^2 \cdot \text{sex} \cdot \beta_{\text{sexage}^2} + 
-        \text{age}^2 \cdot \beta_{\text{age}^2}
+    P(y^{(i)} = k) = P(y^{(i)} \leq k) - P(y^{(i)} \leq k-1)
 
 
 Step 4: Compute the number of asthma exacerbations in the current timepoint

--- a/docs/model/model-statistical-background.rst
+++ b/docs/model/model-statistical-background.rst
@@ -32,6 +32,8 @@ where :math:`i` is the index of the sample, :math:`n` is the number of features,
 :math:`\beta_0, \beta_1, \ldots, \beta_n` are the model coefficients, and
 :math:`x_{1,i}, \ldots, x_{n,i}` are the features of the :math:`i`-th sample.
 
+.. _glm-linear-predictor:
+
 GLM: Linear Predictor
 -----------------------
 
@@ -226,15 +228,16 @@ levels are arbitrary. Rather than modelling a single mean, the model predicts th
 
 .. math::
 
-  P(y \leq k) = \sigma(\theta_k + \eta)
+  P(y^{(i)} \leq k) = \sigma(\theta_k + \eta^{(i)})
 
-where :math:`\theta_k` is the threshold parameter for level :math:`k`, :math:`\eta` is the
-linear predictor, and :math:`\sigma(x) = \dfrac{1}{1 + e^{-x}}` is the logistic function.
-The probability of being in exactly level :math:`k` follows from the cumulative probabilities:
+where :math:`\theta_k` is the threshold parameter for level :math:`k`, :math:`\eta^{(i)}` is the
+:ref:`linear predictor <glm-linear-predictor>`, and :math:`\sigma(x) = \dfrac{1}{1 + e^{-x}}` is the
+logistic function. The probability of being in exactly level :math:`k` follows from the cumulative
+probabilities:
 
 .. math::
 
-  P(y = k) = P(y \leq k) - P(y \leq k - 1)
+  P(y^{(i)} = k) = P(y^{(i)} \leq k) - P(y^{(i)} \leq k - 1)
 
 A patient-specific random effect :math:`\beta_0^{(i)} \sim \mathcal{N}(0, \sigma^2)` can be
 added to the linear predictor to account for within-subject correlation across repeated

--- a/docs/model/model-statistical-background.rst
+++ b/docs/model/model-statistical-background.rst
@@ -214,6 +214,38 @@ predictor :math:`\eta^{(i)}` can be any real number:
 This is the distribution family used in LEAP's :ref:`antibiotic_exposure_model` to predict
 per-capita antibiotic exposure rates.
 
+.. _ordinal-regression:
+
+Example 4: Ordinal Regression with Logit Link
+-----------------------------------------------
+
+Ordinal regression is used when the response variable is ordered but the intervals between
+levels are arbitrary. Rather than modelling a single mean, the model predicts the
+**cumulative probability** of being at or below each level :math:`k` using the logistic
+(sigmoid) function as the link:
+
+.. math::
+
+  P(y \leq k) = \sigma(\theta_k + \eta)
+
+where :math:`\theta_k` is the threshold parameter for level :math:`k`, :math:`\eta` is the
+linear predictor, and :math:`\sigma(x) = \dfrac{1}{1 + e^{-x}}` is the logistic function.
+The probability of being in exactly level :math:`k` follows from the cumulative probabilities:
+
+.. math::
+
+  P(y = k) = P(y \leq k) - P(y \leq k - 1)
+
+A patient-specific random effect :math:`\beta_0^{(i)} \sim \mathcal{N}(0, \sigma^2)` can be
+added to the linear predictor to account for within-subject correlation across repeated
+measurements, giving:
+
+.. math::
+
+  P(y^{(i)} \leq k) = \sigma\!\left(\theta_k + \eta^{(i)} + \beta_0^{(i)}\right)
+
+This is the model used in LEAP's :ref:`control-model` to predict asthma control level.
+
 .. _contingency-tables:
 
 Contingency Tables


### PR DESCRIPTION
## Description

Minor changes to the Asthma Control Model documentation page (`model-control.rst`) to align with the style established in `model-birth.rst`, `model-family-history.rst`, and `model-occurrence.rst`. Key changes:

- Condenses the EBA study description and data cleaning notes, removing redundancies
- Replaces the verbose "Ordinal Regression" and "Random Effects" subsections with a single model section using `logit` notation, shorthand variables (`a_i`, `s_i`), and a Coefficient/Indices/Term/Description table consistent with `model-occurrence.rst`
- Moves the ordinal regression and random effects background to `model-statistical-background.rst` as Example 4 under Generalized Linear Models
- Removes the redundant repeated formula from the Predictions section
- Updates both asthma control formula instances in `model-simulation.rst` (Step 5 initialization and Step 3 lifetime iteration) to use logit notation, consistent coefficient names, multiplication dots, and k ∈ {1, 2, 3} indexing matching the rest of the documentation

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

Documentation-only change. No code was modified.

- [x] Verified all cross-references between `model-control.rst`, `model-statistical-background.rst`, and `model-simulation.rst` are intact
- [x] Confirmed no information from the original Ordinal Regression and Random Effects sections was lost in the move to `model-statistical-background.rst`

## Linked PRs / Issues

N/A

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
