### PR TITLE
Update exacerbation documentation

### DIFF
--- a/docs/_static/bibliography.bib
+++ b/docs/_static/bibliography.bib
@@ -69,6 +69,18 @@
     url = {https://www.ginasthma.org/reports}
 }
 
+@article{lee2022natural,
+    author = {Lee, Tae Yoon and Petkau, John and Sadatsafavi, Mohsen},
+    title = {Long-term natural history of severe asthma exacerbations and their impact on the disease course},
+    journal = {Annals of the American Thoracic Society},
+    volume = {19},
+    number = {6},
+    pages = {907--915},
+    year = {2022},
+    doi = {10.1513/AnnalsATS.202012-1562OC},
+    url = {https://doi.org/10.1513/AnnalsATS.202012-1562OC}
+}
+
 @article{dipietrantonj2006,
     author = {Di Pietrantonj C.},
     title = {Four-fold table cell frequencies imputation in meta analysis},

--- a/docs/_static/bibliography.bib
+++ b/docs/_static/bibliography.bib
@@ -1,79 +1,18 @@
-@article {leap2024,
-	author = {
+@article{leap2024,
+    author = {
         Lee, Tae Yoon and Petkau, John and Johnson, Kate M. and Turvey, Stuart E. and Adibi, Amin
-        and Subbarao, Padmaja and Sadatsafavi, Mohsen
+        and Subbarao, Padmaja and Hill, Ainsleigh and Ewert, Mark and Sadatsafavi, Mohsen
     },
-	title = "{
-        Development and Validation of an Asthma Policy Model for Canada:
-        Lifetime Exposures and Asthma outcomes Projection (LEAP)
-    }",
-	elocation-id = {2024.03.11.24304122},
-	year = {2024},
-	doi = {10.1101/2024.03.11.24304122},
-	publisher = {Cold Spring Harbor Laboratory Press},
-	abstract = "{Purpose To develop Lifetime Exposures and Asthma outcomes Projection (LEAP), 
-        a reference policy model for evaluating health outcomes and costs of asthma interventions
-        and policies for the Canadian population.Methods Following the best practice guidelines for
-        development, we first created a conceptual map with a steering committee of clinician
-        experts and economic modelers through a modified Delphi-process. Following the
-        committee{\textquoteright}s recommendations and given the multidimensionality of risk
-        factors and the need for modeling realistic aspects (e.g., gradual market penetration) of
-        adopting health technologies, we opted for an open-population microsimulation design.
-        For the first version of the model, we concentrated on several key risk factors
-        (age, sex, family history of asthma at birth, and exposure to antibiotics in the
-        first year of life) from the concept map.The model consists of five intertwined modules:
-        1) demographic, 2) risk factors, 3) asthma occurrence, 4) asthma outcomes, and 5) payoffs.
-        The demographic module, including birth, mortality, immigration, and emigration,
-        was based on sex{\textendash} and age-specific estimates and projections from
-        Statistics Canada. The distributions of risk factors, including family history of asthma
-        and exposure to antibiotics, were estimated from population-based administrative databases
-        and a population-based longitudinal birth cohort. To estimate parameters in the asthma
-        occurrence (prevalence, incidence, reassessment) and asthma outcomes
-        (severity, symptom control, exacerbations) modules, we performed quantitative evidence
-        synthesis. Costs and utility weights were obtained from the literature.
-        We conducted multiple face and internal validation assessments. Results: LEAP is capable
-        of modeling asthma-related health outcomes at the individual and aggregate levels from
-        2001 onwards. Face validity was confirmed by checking the structure, equations, codes,
-        and results. We calibrated and internally validated the age-sex stratified demographic
-        projections to the estimates and projections from Statistics Canada, the age-sex stratified
-        asthma prevalence to the administrative data, and the asthma control levels and exacerbation
-        rates to the estimates from the literature.Conclusions LEAP is the first reference Canadian
-        asthma policy model that emerged from identified needs for health policy planning for early
-        interventions in asthma. As an open-source and open-access platform, LEAP can provide a
-        unified framework under which different interventions and policies can be consistently
-        compared to identify those with the highest value proposition.Funding This study was funded
-        by a research grant from the Canadian Institutes of Health Research and Genome Canada
-        (274CHI). The funders had no role in any aspect of this study and were not aware of the
-        results. Ethics: This study was approved by the institutional review board of the
-        University of British Columbia, Vancouver (H22-00571).
-        Competing Interest Statement: The authors have declared no competing interest.
-        Funding Statement: This study was funded by a research grant from the
-        Canadian Institutes of Health Research and Genome Canada (274CHI).
-        The funders had no role in any aspect of this study and were not aware of the results.
-        Author Declarations: I confirm all relevant ethical guidelines have been followed, and any
-        necessary IRB and/or ethics committee approvals have been obtained.YesThe details of the
-        IRB/oversight body that provided approval or exemption for the research described are
-        given below: This study was approved by the institutional review board of the
-        University of British Columbia, Vancouver (H22-00571). I confirm that all necessary
-        patient/participant consent has been obtained and the appropriate institutional forms have
-        been archived, and that any patient/participant/sample identifiers included were not known
-        to anyone (e.g., hospital staff, patients or participants themselves) outside the research
-        group so cannot be used to identify individuals.YesI understand that all clinical trials
-        and any other prospective interventional studies must be registered with an ICMJE-approved
-        registry, such as ClinicalTrials.gov. I confirm that any such study reported in the
-        manuscript has been registered and the trial registration ID is provided
-        (note: if posting a prospective study registered retrospectively, please provide a
-        statement in the trial ID field explaining why the study was not registered in advance).
-        YesI have followed all appropriate research reporting guidelines, such as any relevant
-        EQUATOR Network research reporting checklist(s) and other pertinent material, if applicable.
-        YesAll data open to the public are available online at https://github.com/tyhlee/LEAP.jl. 
-        The CHILD study cohort data is not open to the public. One can obtain access by following 
-        the procedures: 
-        https://childstudy.ca/for-researchers/data-access/.https://github.com/tyhlee/LEAP.jl
-    }",
-	URL = {https://www.medrxiv.org/content/early/2024/03/13/2024.03.11.24304122},
-	eprint = {https://www.medrxiv.org/content/early/2024/03/13/2024.03.11.24304122.full.pdf},
-	journal = {medRxiv}
+    title = {Development of an asthma policy model for Canada: Lifetime Exposures and Asthma
+        outcomes Projection},
+    journal = {PLOS One},
+    volume = {21},
+    number = {5},
+    pages = {e0348878},
+    year = {2026},
+    publisher = {Public Library of Science},
+    doi = {10.1371/journal.pone.0348878},
+    url = {https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0348878}
 }
 
 @article {mamun2019,
@@ -120,6 +59,14 @@
     url={https://www.frontiersin.org/journals/allergy/articles/10.3389/falgy.2024.1491985},
     doi={10.3389/falgy.2024.1491985},
     ISSN={2673-6101}
+}
+
+@misc{gina2023,
+    author = {{Global Initiative for Asthma}},
+    title = {Global strategy for asthma management and prevention},
+    year = {2023},
+    note = {Updated 2023},
+    url = {https://www.ginasthma.org/reports}
 }
 
 @article{dipietrantonj2006,

--- a/docs/dev/api/data_generation/leap.data_generation.exacerbation_data.rst
+++ b/docs/dev/api/data_generation/leap.data_generation.exacerbation_data.rst
@@ -41,7 +41,7 @@ The formula is:
 .. math::
 
    \begin{align}
-   N_{\text{exacerbations}} &\sim \text{Poisson}(\lambda) = \dfrac{\lambda^k e^{-\lambda}}{k!}
+   N_{\text{exacerbations}} &\sim \text{Poisson}(\lambda) = \dfrac{\lambda^{\kappa} e^{-\lambda}}{\kappa!}
    \end{align}
 
 Here :math:`\lambda` is the expected number of exacerbations per year. To obtain :math:`\lambda`,
@@ -51,7 +51,7 @@ interested in can be approximated using the following formula:
 .. math::
 
    \begin{align}
-   \ln(\lambda) &= \ln(\alpha) + \beta_0 + \beta_{a} a + \beta_{s} s + \sum_{i=1}^3 \beta_i c_i 
+   \ln(\lambda) &= \ln(\alpha) + \beta_0 + \beta_{a} a + \beta_{s} s + \sum_{k=1}^3 \beta_k c_k
    \end{align}
 
 where:
@@ -61,8 +61,8 @@ where:
 * :math:`\beta_a`: age constant
 * :math:`s`: sex
 * :math:`\beta_s`: sex constant
-* :math:`c_i`: relative time spent in control level :math:`i`
-* :math:`\beta_i`: control level constant
+* :math:`c_k`: relative time spent in control level :math:`k`
+* :math:`\beta_k`: control level constant
 
 In the ``exacerbation_data.py`` file, we are interested in calculating :math:`\alpha`. If we
 rewrite the equation, the meaning of :math:`\alpha` becomes more apparent:
@@ -70,7 +70,7 @@ rewrite the equation, the meaning of :math:`\alpha` becomes more apparent:
 .. math::
 
    \begin{align}
-   \lambda &= \alpha \cdot e^{\beta_0} e^{\beta_{a} a} e^{\beta_{s} s} \prod_{i=1}^3 e^{\beta_i c_i} 
+   \lambda &= \alpha \cdot e^{\beta_0} e^{\beta_{a} a} e^{\beta_{s} s} \prod_{k=1}^3 e^{\beta_k c_k}
    \end{align}
 
 
@@ -80,14 +80,14 @@ Poisson regression, with the following formula:
 .. math::
 
    \begin{align}
-   \ln(\lambda_{C}) &= \sum_{i=1}^3 \gamma_i c_i 
+   \ln(\lambda_{C}) &= \sum_{k=1}^3 \gamma_k c_k
    \end{align}
 
 * :math:`\lambda_C`: the average number of exacerbations in a given year
-* :math:`c_i`: relative time spent in control level :math:`i`
-* :math:`\gamma_i`: control level constant (different from :math:`\beta_i` above)
+* :math:`c_k`: relative time spent in control level :math:`k`
+* :math:`\gamma_k`: control level constant (different from :math:`\beta_k` above)
 
-Here, the :math:`\gamma_i` values were calculated from the
+Here, the :math:`\gamma_k` values were calculated from the
 `Economic Burden of Asthma (EBA) study <https://bmjopen.bmj.com/content/3/9/e003360.long>`_
 and are given by:
 

--- a/docs/dev/api/data_generation/leap.data_generation.exacerbation_data.rst
+++ b/docs/dev/api/data_generation/leap.data_generation.exacerbation_data.rst
@@ -1,6 +1,40 @@
 Exacerbation Calibration Data
 =============================
 
+.. _exacerbation-raw-data-files:
+
+Raw Data Files
+**************
+
+Each province subfolder under
+`original_data/asthma_hosp/{province}/
+<https://github.com/resplab/leap/tree/main/leap/original_data/asthma_hosp>`_
+contains 5 files that share the same columns and shape, differing only in what value is
+reported. See :ref:`tab1-rate-columns` for a description of ``tab1_rate.csv``, the only one of
+these 5 files used to calibrate the exacerbation model.
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - File
+     - Description
+   * - ``tab1_count.csv``
+     - the number of people hospitalized with asthma.
+   * - ``tab1_N.csv``
+     - the total number of people in the category (the denominator used to compute the rate).
+   * - ``tab1_lower.csv``
+     - the lower error bar for the hospitalization rate.
+   * - ``tab1_upper.csv``
+     - the upper error bar for the hospitalization rate.
+
+Each province subfolder also contains a ``los.csv`` file with length-of-stay statistics
+(``avg``, ``med``, ``q1``, ``q3``) by ``fiscal_year``, ``age_group``, and ``sex``. This dataset
+is not currently used by the exacerbation model.
+
+Calibration Multiplier
+***********************
+
 The number of exacerbations in a given year is modelled using a Poisson distribution.
 The formula is:
 

--- a/docs/model/index.rst
+++ b/docs/model/index.rst
@@ -20,6 +20,7 @@ outcomes over a lifetime.
   model-reassessment
   model-control
   model-exacerbation
+  model-exacerbation-severity
   model-cost
   model-utility
   model-pollution

--- a/docs/model/model-birth.rst
+++ b/docs/model/model-birth.rst
@@ -124,6 +124,14 @@ For both sources, only the ``AGE_GROUP = 0`` (newborns) rows are used. The ``N``
 represents the total number of births (both sexes combined), and ``prop_male`` is derived as
 the number of male births divided by the total.
 
+The same two source tables, using all ``AGE_GROUP`` rows rather than just newborns, are also used
+by ``birth_data.py`` to produce a second processed file:
+`leap/processed_data/{time_delta_tag}/birth/initial_population.csv
+<https://github.com/resplab/leap/blob/main/leap/processed_data/time_delta_365/birth/initial_population.csv>`_.
+This file gives the population count by age (rather than just births), and is used by the
+migration and exacerbation models — see the Population Data section in :doc:`model-migration` for
+its schema.
+
 .. list-table::
    :widths: 25 25 50
    :header-rows: 1

--- a/docs/model/model-exacerbation-severity.rst
+++ b/docs/model/model-exacerbation-severity.rst
@@ -45,19 +45,52 @@ first drawn from a Dirichlet distribution:
 
     \mathbf{w}^{\text{pre},(i)} \sim \text{Dirichlet}(\boldsymbol{\delta})
 
-:math:`\mathbf{w}^{\text{pre},(i)} = (w^{\text{pre},(i)}_{\text{mild}}, w^{\text{pre},(i)}_{\text{moderate}},
-w^{\text{pre},(i)}_{\text{severe}}, w^{\text{pre},(i)}_{\text{very severe}})` is a length-4 vector of
+The vector :math:`\mathbf{w}^{\text{pre},(i)}` is defined as a length-4 vector of
 *probabilities* (summing to 1) giving this individual's personal probability of each severity
-level. For each agent with asthma, :math:`\mathbf{w}^{\text{pre},(i)}` is sampled once, independently
+level:
+
+.. math::
+
+  \mathbf{w}^{\text{pre},(i)} := \begin{bmatrix}
+    w^{\text{pre},(i)}_{\text{mild}} &
+    w^{\text{pre},(i)}_{\text{moderate}} &
+    w^{\text{pre},(i)}_{\text{severe}} &
+    w^{\text{pre},(i)}_{\text{very severe}}
+  \end{bmatrix}
+  
+For each agent with asthma, :math:`\mathbf{w}^{\text{pre},(i)}` is sampled once, independently
 per agent, and held fixed for their simulated lifetime — representing individual heterogeneity in
 exacerbation severity, distinct from (and prior to) the adjustment for previous hospitalization
 described below. The actual exacerbation counts are determined later using
 :math:`N_{\text{exacerbations}}^{(i)}` (the total count, from the Poisson model above) together with
 this probability vector.
 
-:math:`\boldsymbol{\delta} = \kappa \cdot \mathbf{p}` is the Dirichlet concentration vector,
-:math:`\mathbf{p} = (p_{\text{mild}}, p_{\text{moderate}}, p_{\text{severe}}, p_{\text{very severe}})
-= (0.495, 0.195, 0.283, 0.026)` are the same SYGMA II severity proportions used for
+The vector :math:`\boldsymbol{\delta}` is the ``Dirichlet concentration vector``:
+
+.. math::
+
+  \boldsymbol{\delta} = \kappa \cdot \mathbf{p}
+
+
+where:
+
+.. math::
+
+  \mathbf{p} &= \begin{bmatrix}
+    p_{\text{mild}} &
+    p_{\text{moderate}} &
+    p_{\text{severe}} &
+    p_{\text{very severe}}
+  \end{bmatrix} \\
+  &= \begin{bmatrix}
+    0.495 &
+    0.195 &
+    0.283 &
+    0.026
+  \end{bmatrix}
+
+
+are the same SYGMA II severity proportions used for
 :math:`P(\text{hosp})` in the :ref:`Calibration <exacerbation-calibration>` section of the
 :ref:`exacerbation-model` :cite:`leap2024`, and :math:`\kappa = 100` is an assumed concentration
 multiplier controlling how tightly an individual's probabilities cluster around the
@@ -72,16 +105,16 @@ proportionally across the other three levels:
 
 .. math::
 
-    w_{\text{very severe}}^{(i)} &= w^{\text{pre},(i)}_{\text{very severe}} \cdot \beta_{\text{prev hosp}}^{(i)} \\
-    w_j^{(i)} &= \dfrac{w^{\text{pre},(i)}_j}{\sum_{l \,\in\, \{\text{mild, moderate, severe}\}} w^{\text{pre},(i)}_l}
-        \cdot (1 - w_{\text{very severe}}^{(i)}), \quad j \in \{\text{mild, moderate, severe}\}
+  w_j^{(i)} &:= \begin{cases}
+    w^{\text{pre},(i)}_{j} \cdot \beta_{\text{prev hosp}}^{(i)}
+      & \quad j = \text{very severe} \\
+    \dfrac{w^{\text{pre},(i)}_j}{\sum_{\ell \,\in\, \{\text{mild, moderate, severe}\}} w^{\text{pre},(i)}_{\ell}} 
+        \cdot (1 - w_{\text{very severe}}^{(i)})
+        & \quad j \in \{\text{mild, moderate, severe}\}
+  \end{cases}
 
 where:
 
-* :math:`j \in \{\text{mild, moderate, severe}\}`: this equation applies separately to each of
-  these three levels
-* :math:`l \in \{\text{mild, moderate, severe}\}`: a dummy index used only for the summation in
-  the denominator
 * :math:`\beta_{\text{prev hosp}}^{(i)}`: :math:`\beta_{\text{prev hosp,pediatric}} = 1.79` for
   individuals under 14 years of age, or :math:`\beta_{\text{prev hosp,adult}} = 2.88` for
   individuals 14 years of age or older.

--- a/docs/model/model-exacerbation-severity.rst
+++ b/docs/model/model-exacerbation-severity.rst
@@ -35,23 +35,24 @@ The ``very severe`` level is the one used to compute :math:`P(\text{hosp})` and 
 Dirichlet-Multinomial Model
 =============================
 
-Given the total number of exacerbations :math:`N_{\text{exacerbations}}` an individual experiences
-in a time interval (drawn from the Poisson model described in the :ref:`exacerbation-model`), the
-number at each severity level is generated using a Dirichlet-Multinomial distribution. A preliminary
-probability vector across the four levels is first drawn from a Dirichlet distribution:
+Given the total number of exacerbations :math:`N_{\text{exacerbations}}^{(i)}` that agent
+:math:`i` experiences in a time interval (drawn from the Poisson model described in the
+:ref:`exacerbation-model`), the number at each severity level is generated using a
+Dirichlet-Multinomial distribution. A preliminary probability vector across the four levels is
+first drawn from a Dirichlet distribution:
 
 .. math::
 
-    \mathbf{w}^{\text{pre}} \sim \text{Dirichlet}(\boldsymbol{\delta})
+    \mathbf{w}^{\text{pre},(i)} \sim \text{Dirichlet}(\boldsymbol{\delta})
 
-:math:`\mathbf{w}^{\text{pre}} = (w^{\text{pre}}_{\text{mild}}, w^{\text{pre}}_{\text{moderate}},
-w^{\text{pre}}_{\text{severe}}, w^{\text{pre}}_{\text{very severe}})` is a length-4 vector of
+:math:`\mathbf{w}^{\text{pre},(i)} = (w^{\text{pre},(i)}_{\text{mild}}, w^{\text{pre},(i)}_{\text{moderate}},
+w^{\text{pre},(i)}_{\text{severe}}, w^{\text{pre},(i)}_{\text{very severe}})` is a length-4 vector of
 *probabilities* (summing to 1) giving this individual's personal probability of each severity
-level. For each agent with asthma, :math:`\mathbf{w}^{\text{pre}}` is sampled once, independently
+level. For each agent with asthma, :math:`\mathbf{w}^{\text{pre},(i)}` is sampled once, independently
 per agent, and held fixed for their simulated lifetime — representing individual heterogeneity in
 exacerbation severity, distinct from (and prior to) the adjustment for previous hospitalization
 described below. The actual exacerbation counts are determined later using
-:math:`N_{\text{exacerbations}}` (the total count, from the Poisson model above) together with
+:math:`N_{\text{exacerbations}}^{(i)}` (the total count, from the Poisson model above) together with
 this probability vector.
 
 :math:`\boldsymbol{\delta} = \kappa \cdot \mathbf{p}` is the Dirichlet concentration vector,
@@ -71,9 +72,9 @@ proportionally across the other three levels:
 
 .. math::
 
-    w_{\text{very severe}} &= w^{\text{pre}}_{\text{very severe}} \cdot \beta_{\text{prev hosp}} \\
-    w_j &= \dfrac{w^{\text{pre}}_j}{\sum_{l \,\in\, \{\text{mild, moderate, severe}\}} w^{\text{pre}}_l}
-        \cdot (1 - w_{\text{very severe}}), \quad j \in \{\text{mild, moderate, severe}\}
+    w_{\text{very severe}}^{(i)} &= w^{\text{pre},(i)}_{\text{very severe}} \cdot \beta_{\text{prev hosp}}^{(i)} \\
+    w_j^{(i)} &= \dfrac{w^{\text{pre},(i)}_j}{\sum_{l \,\in\, \{\text{mild, moderate, severe}\}} w^{\text{pre},(i)}_l}
+        \cdot (1 - w_{\text{very severe}}^{(i)}), \quad j \in \{\text{mild, moderate, severe}\}
 
 where:
 
@@ -81,7 +82,7 @@ where:
   these three levels
 * :math:`l \in \{\text{mild, moderate, severe}\}`: a dummy index used only for the summation in
   the denominator
-* :math:`\beta_{\text{prev hosp}}`: :math:`\beta_{\text{prev hosp,pediatric}} = 1.79` for
+* :math:`\beta_{\text{prev hosp}}^{(i)}`: :math:`\beta_{\text{prev hosp,pediatric}} = 1.79` for
   individuals under 14 years of age, or :math:`\beta_{\text{prev hosp,adult}} = 2.88` for
   individuals 14 years of age or older.
 
@@ -91,13 +92,13 @@ exacerbation was associated with a 79% increase (rate multiplier 1.79, 95% CI 1.
 rate of subsequent exacerbations for pediatric patients, and a 188% increase (rate multiplier
 2.88, 95% CI 1.35–5.15) for adult patients.
 
-If the individual has no prior hospitalization, :math:`\mathbf{w} = \mathbf{w}^{\text{pre}}`.
+If the individual has no prior hospitalization, :math:`\mathbf{w}^{(i)} = \mathbf{w}^{\text{pre},(i)}`.
 
-Since :math:`\mathbf{w}^{\text{pre}}` already sums to 1, inflating :math:`w_{\text{very severe}}`
-by :math:`\beta_{\text{prev hosp}}` alone would push the total above 1. The :math:`w_j` formula
+Since :math:`\mathbf{w}^{\text{pre},(i)}` already sums to 1, inflating :math:`w_{\text{very severe}}^{(i)}`
+by :math:`\beta_{\text{prev hosp}}^{(i)}` alone would push the total above 1. The :math:`w_j^{(i)}` formula
 corrects this: it proportionally shrinks the mild/moderate/severe probabilities so the full
-vector :math:`\mathbf{w}` sums back to 1, while keeping their relative proportions to each other
-unchanged from :math:`\mathbf{w}^{\text{pre}}`.
+vector :math:`\mathbf{w}^{(i)}` sums back to 1, while keeping their relative proportions to each other
+unchanged from :math:`\mathbf{w}^{\text{pre},(i)}`.
 
 
 This raises the question of how "previously hospitalized" is determined for an agent whose
@@ -106,9 +107,9 @@ asthma label and a diagnosis age all at once when they enter the simulation. See
 :ref:`step-4-check-hospitalizations` for how this is initialized in that case.
 
 Finally, the number of exacerbations at each severity level is drawn from a Multinomial
-distribution, using :math:`N_{\text{exacerbations}}` as the number of trials:
+distribution, using :math:`N_{\text{exacerbations}}^{(i)}` as the number of trials:
 
 .. math::
 
-    (n_{\text{mild}}, n_{\text{moderate}}, n_{\text{severe}}, n_{\text{very severe}})
-        \sim \text{Multinomial}(N_{\text{exacerbations}}, \mathbf{w})
+    (n_{\text{mild}}^{(i)}, n_{\text{moderate}}^{(i)}, n_{\text{severe}}^{(i)}, n_{\text{very severe}}^{(i)})
+        \sim \text{Multinomial}(N_{\text{exacerbations}}^{(i)}, \mathbf{w}^{(i)})

--- a/docs/model/model-exacerbation-severity.rst
+++ b/docs/model/model-exacerbation-severity.rst
@@ -1,0 +1,114 @@
+.. _exacerbation_severity_model:
+
+=====================================
+Asthma Exacerbation Severity Model
+=====================================
+
+Each asthma exacerbation is assigned one of four severity levels, classified retrospectively by
+the level of healthcare utilization required to treat it, following the framework described by
+the Global Initiative for Asthma (GINA) :cite:`gina2023`:
+
+.. list-table::
+   :widths: 10 20 70
+   :header-rows: 1
+
+   * - Level
+     - Name
+     - Healthcare utilization
+   * - 1
+     - Mild
+     - managed with reliever medication alone
+   * - 2
+     - Moderate
+     - requires a physician visit and a prescription of oral corticosteroids (OCS)
+   * - 3
+     - Severe
+     - requires an emergency department (ED) visit
+   * - 4
+     - Very severe
+     - requires hospital admission
+
+The ``very severe`` level is the one used to compute :math:`P(\text{hosp})` and calibrate
+:math:`\alpha` in the :ref:`Calibration <exacerbation-calibration>` section of the
+:ref:`exacerbation-model`, and is what the Hospitalization Data described in that section measures.
+
+Dirichlet-Multinomial Model
+=============================
+
+Given the total number of exacerbations :math:`N_{\text{exacerbations}}` an individual experiences
+in a time interval (drawn from the Poisson model described in the :ref:`exacerbation-model`), the
+number at each severity level is generated using a Dirichlet-Multinomial distribution. A preliminary
+probability vector across the four levels is first drawn from a Dirichlet distribution:
+
+.. math::
+
+    \mathbf{w}^{\text{pre}} \sim \text{Dirichlet}(\boldsymbol{\delta})
+
+:math:`\mathbf{w}^{\text{pre}} = (w^{\text{pre}}_{\text{mild}}, w^{\text{pre}}_{\text{moderate}},
+w^{\text{pre}}_{\text{severe}}, w^{\text{pre}}_{\text{very severe}})` is a length-4 vector of
+*probabilities* (summing to 1) giving this individual's personal probability of each severity
+level. For each agent with asthma, :math:`\mathbf{w}^{\text{pre}}` is sampled once, independently
+per agent, and held fixed for their simulated lifetime — representing individual heterogeneity in
+exacerbation severity, distinct from (and prior to) the adjustment for previous hospitalization
+described below. The actual exacerbation counts are determined later using
+:math:`N_{\text{exacerbations}}` (the total count, from the Poisson model above) together with
+this probability vector.
+
+:math:`\boldsymbol{\delta} = \kappa \cdot \mathbf{p}` is the Dirichlet concentration vector,
+:math:`\mathbf{p} = (p_{\text{mild}}, p_{\text{moderate}}, p_{\text{severe}}, p_{\text{very severe}})
+= (0.495, 0.195, 0.283, 0.026)` are the same SYGMA II severity proportions used for
+:math:`P(\text{hosp})` in the :ref:`Calibration <exacerbation-calibration>` section of the
+:ref:`exacerbation-model` :cite:`leap2024`, and :math:`\kappa = 100` is an assumed concentration
+multiplier controlling how tightly an individual's probabilities cluster around the
+population proportions :math:`\mathbf{p}`.
+
+Adjustment for Previous Hospitalization
+=========================================
+
+If the individual has previously been hospitalized for an asthma exacerbation, their probability
+of a very severe exacerbation is increased, and the remaining probability mass is redistributed
+proportionally across the other three levels:
+
+.. math::
+
+    w_{\text{very severe}} &= w^{\text{pre}}_{\text{very severe}} \cdot \beta_{\text{prev hosp}} \\
+    w_j &= \dfrac{w^{\text{pre}}_j}{\sum_{l \,\in\, \{\text{mild, moderate, severe}\}} w^{\text{pre}}_l}
+        \cdot (1 - w_{\text{very severe}}), \quad j \in \{\text{mild, moderate, severe}\}
+
+where:
+
+* :math:`j \in \{\text{mild, moderate, severe}\}`: this equation applies separately to each of
+  these three levels
+* :math:`l \in \{\text{mild, moderate, severe}\}`: a dummy index used only for the summation in
+  the denominator
+* :math:`\beta_{\text{prev hosp}}`: :math:`\beta_{\text{prev hosp,pediatric}} = 1.79` for
+  individuals under 14 years of age, or :math:`\beta_{\text{prev hosp,adult}} = 2.88` for
+  individuals 14 years of age or older.
+
+These rate multipliers are taken from a Canadian cohort study of the long-term natural history of
+severe asthma exacerbations :cite:`lee2022natural`, which found that a first follow-up severe
+exacerbation was associated with a 79% increase (rate multiplier 1.79, 95% CI 1.11–2.89) in the
+rate of subsequent exacerbations for pediatric patients, and a 188% increase (rate multiplier
+2.88, 95% CI 1.35–5.15) for adult patients.
+
+If the individual has no prior hospitalization, :math:`\mathbf{w} = \mathbf{w}^{\text{pre}}`.
+
+Since :math:`\mathbf{w}^{\text{pre}}` already sums to 1, inflating :math:`w_{\text{very severe}}`
+by :math:`\beta_{\text{prev hosp}}` alone would push the total above 1. The :math:`w_j` formula
+corrects this: it proportionally shrinks the mild/moderate/severe probabilities so the full
+vector :math:`\mathbf{w}` sums back to 1, while keeping their relative proportions to each other
+unchanged from :math:`\mathbf{w}^{\text{pre}}`.
+
+
+This raises the question of how "previously hospitalized" is determined for an agent whose
+asthma history was not directly simulated cycle-by-cycle — for example, an agent assigned an
+asthma label and a diagnosis age all at once when they enter the simulation. See
+:ref:`step-4-check-hospitalizations` for how this is initialized in that case.
+
+Finally, the number of exacerbations at each severity level is drawn from a Multinomial
+distribution, using :math:`N_{\text{exacerbations}}` as the number of trials:
+
+.. math::
+
+    (n_{\text{mild}}, n_{\text{moderate}}, n_{\text{severe}}, n_{\text{very severe}})
+        \sim \text{Multinomial}(N_{\text{exacerbations}}, \mathbf{w})

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -233,18 +233,18 @@ The formula is:
 
 .. math::
 
-    N_{\text{exacerbations}} \sim \text{Poisson}(\lambda) = \dfrac{\lambda^{\kappa} e^{-\lambda}}{\kappa!}
+    N_{\text{exacerbations}}^{(i)} \sim \text{Poisson}(\lambda^{(i)}) = \dfrac{{\lambda^{(i)}}^{\kappa} e^{-\lambda^{(i)}}}{\kappa!}
 
 
-Here :math:`\lambda` is the expected number of exacerbations per time interval, and :math:`\kappa` is
-the number of exacerbations (a non-negative integer) for which we are computing the
-probability. To obtain :math:`\lambda`, we must perform a Poisson regression. The Poisson
-regression assumes that the value we are interested in can be approximated using the following
-formula:
+Here :math:`\lambda^{(i)}` is the expected number of exacerbations per time interval for agent
+:math:`i`, and :math:`\kappa` is the number of exacerbations (a non-negative integer) for which we
+are computing the probability. To obtain :math:`\lambda^{(i)}`, we must perform a Poisson
+regression. The Poisson regression assumes that the value we are interested in can be
+approximated using the following formula:
 
 .. math::
 
-    \ln(\lambda) = \ln(\alpha) + \beta_0^{(i)} + \sum_{k=1}^3 \beta_k c_k
+    \ln(\lambda^{(i)}) = \ln(\alpha) + \beta_0^{(i)} + \sum_{k=1}^3 \beta_k c_k^{(i)}
 
 
 where:
@@ -259,7 +259,7 @@ where:
      - the calibration multiplier that adjusts the model to match the hospitalization data
    * - :math:`\beta_0^{(i)}`
      - patient-specific random effect; :math:`\beta_0^{(i)} \sim \mathcal{N}(0, \sigma^2)`
-   * - :math:`c_k`
+   * - :math:`c_k^{(i)}`
      - relative time spent in control level :math:`k`, given by the probability of control level
        :math:`k` from the :ref:`Control Model <control-model>`
    * - :math:`\beta_k`
@@ -272,35 +272,36 @@ mean and variance of this distribution are configuration-dependent; in the curre
 configuration they are set to approximately :math:`\mathcal{N}(0, 0)`, effectively disabling this
 source of individual variation.
 
-This gives us the rate :math:`\lambda` of exacerbations of *any* severity. Once an individual's
+This gives us the rate :math:`\lambda^{(i)}` of exacerbations of *any* severity. Once an individual's
 total number of exacerbations for a time interval is drawn from this Poisson model, each
 exacerbation is further assigned a severity level (mild, moderate, severe, or very severe) — see
 the :ref:`exacerbation_severity_model`.
 
-The diagram below summarises how these pieces fit together conceptually, for a given age
-:math:`a` and sex :math:`s`, from calibration through to the final severity-level counts.
+The diagram below summarises how these pieces fit together conceptually, for agent :math:`i` with
+a given age :math:`a` and sex :math:`s`, from calibration through to the final severity-level
+counts.
 
 .. md-mermaid::
 
     flowchart TD
         ALPHA["<b>Calibration multiplier</b>&nbsp;<span style='font-size:1.3em'>$$\alpha$$</span><br/>predicted vs. observed<br/>hospitalizations in CIHI data"]
-        BI["<b>Control-level rate constants</b>&nbsp;<span style='font-size:1.3em'>$$\beta_i$$</span><br/>derived from EBA + GOAL studies"]
-        CI["<b>Control-level probabilities</b>&nbsp;<span style='font-size:1.3em'>$$c_i$$</span><br/>predicted by the Control Model"]
+        BI["<b>Control-level rate constants</b>&nbsp;<span style='font-size:1.3em'>$$\beta_k$$</span><br/>derived from EBA + GOAL studies"]
+        CI["<b>Control-level probabilities</b>&nbsp;<span style='font-size:1.3em'>$$c_k^{(i)}$$</span><br/>predicted by the Control Model"]
 
-        RATE["<b>Rate of exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$\lambda$$</span><br/>(any severity)"]
+        RATE["<b>Rate of exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$\lambda^{(i)}$$</span><br/>(any severity)"]
 
         ALPHA --> RATE
         BI --> RATE
         CI --> RATE
 
-        COUNT["<b>Total exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$N_{\text{exacerbations}}$$</span><br/>this time interval"]
+        COUNT["<b>Total exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$N_{\text{exacerbations}}^{(i)}$$</span><br/>this time interval"]
         RATE --> COUNT
 
-        SEV["<b>Severity probabilities</b>&nbsp;<span style='font-size:1.3em'>$$\mathbf{w}$$</span><br/>based on SYGMA II<br/>severity/hospitalization proportions"]
-        HIST["<b>History of very severe</b><br/><b>exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$\beta_{\text{prev hosp}}$$</span><br/>(hospitalization)"]
+        SEV["<b>Severity probabilities</b>&nbsp;<span style='font-size:1.3em'>$$\mathbf{w}^{(i)}$$</span><br/>based on SYGMA II<br/>severity/hospitalization proportions"]
+        HIST["<b>History of very severe</b><br/><b>exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$\beta_{\text{prev hosp}}^{(i)}$$</span><br/>(hospitalization)"]
         HIST -->|"increases probability<br/>of very severe"| SEV
 
-        OUTPUT["<b>Exacerbations by</b><br/><b>severity level</b>&nbsp;<span style='font-size:1.3em'>$$(n_{\text{mild}}, \ldots, n_{\text{very severe}})$$</span>"]
+        OUTPUT["<b>Exacerbations by</b><br/><b>severity level</b>&nbsp;<span style='font-size:1.3em'>$$(n_{\text{mild}}^{(i)}, \ldots, n_{\text{very severe}}^{(i)})$$</span>"]
         COUNT --> OUTPUT
         SEV --> OUTPUT
 
@@ -328,7 +329,7 @@ We are interested in calculating :math:`\alpha`. If we rewrite the equation, the
 
 .. math::
 
-    \lambda = \alpha \cdot e^{\beta_0^{(i)}} \prod_{k=1}^3 e^{\beta_k c_k}
+    \lambda^{(i)} = \alpha \cdot e^{\beta_0^{(i)}} \prod_{k=1}^3 e^{\beta_k c_k^{(i)}}
 
 
 How do we obtain :math:`\alpha`? We again assume that the mean value has the same form as in a
@@ -445,7 +446,7 @@ from the observed hospitalization rate in CIHI as described in :ref:`tab1-rate-c
   :collapsible:
 
   Although :math:`\alpha` is computed from hospitalizations alone, it is applied to
-  :math:`\lambda`, the rate of exacerbations of *any* severity — this is valid because
+  :math:`\lambda^{(i)}`, the rate of exacerbations of *any* severity — this is valid because
   :math:`P(\text{hosp})` is treated as a fixed constant, independent of age, sex, province, and
   timepoint. Substituting
   :math:`N_{\text{hosp}}^{\text{(pred)}} = N_{\text{exac}}^{\text{(pred)}} \cdot P(\text{hosp})`,
@@ -472,7 +473,7 @@ and saved as:
 `processed_data/{time_delta_tag}/exacerbation_calibration.csv
 <https://github.com/resplab/leap/blob/main/leap/processed_data/time_delta_365/exacerbation_calibration.csv>`_.
 This file is looked up at simulation runtime — by province, timepoint, sex, and age — to
-calibrate each agent's :math:`\lambda`.
+calibrate each agent's :math:`\lambda^{(i)}`.
 
 Processed Data
 ^^^^^^^^^^^^^^^^

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -11,8 +11,8 @@ Population Data
 *****************
 
 We use the Statistics Canada population data that was generated and saved as:
-`processed_data/birth/initial_population.csv 
-<https://github.com/resplab/leap/blob/main/leap/processed_data/birth/initial_population.csv>`_.
+`processed_data/{time_delta_tag}/birth/initial_population.csv
+<https://github.com/resplab/leap/blob/main/leap/processed_data/time_delta_365/birth/initial_population.csv>`_.
 
 
 .. list-table::
@@ -56,8 +56,8 @@ Occurrence Data
 ******************
 
 We use the occurrence data that was generated and saved as:
-`processed_data/asthma_occurrence_predictions.csv 
-<https://github.com/resplab/leap/blob/main/leap/data_generation/processed_data/asthma_occurrence_predictions.csv>`_
+`processed_data/{time_delta_tag}/asthma_occurrence_predictions.csv
+<https://github.com/resplab/leap/blob/main/leap/processed_data/time_delta_365/asthma_occurrence_predictions.csv>`_
 
 See :ref:`occurrence-model-1` for more details about this dataset.
 
@@ -90,18 +90,59 @@ Hospitalization Data
 ***********************
 
 The data is from the ``Hospital Morbidity Database (HMDB)`` from the
-`Canadian Institute for Health Information (CIHI) 
+`Canadian Institute for Health Information (CIHI)
 <https://www.cihi.ca/en/hospital-morbidity-database-hmdb-metadata>`_.
 
 The hospitalization data was collected from patients presenting to a hospital in Canada
 due to an asthma exacerbation. We will use this data to calibrate the exacerbation model.
 
+Per-province Structure
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The raw data is saved under
+`original_data/asthma_hosp/{province}/
+<https://github.com/resplab/leap/tree/main/leap/original_data/asthma_hosp>`_,
+with one subfolder per province/territory: ``AB``, ``BC``, ``MB``, ``NB``, ``NL``, ``NS``,
+``ON``, ``PE``, ``QC``, ``SK``. In addition there are two combined regions:
+
+* ``CA``: all of Canada combined.
+* ``TR``: Nunavut, Northwest Territories, and Yukon combined into a single category, since
+  each of these territories individually has too few cases to report reliably.
+
+Each province subfolder contains 5 files that share the same columns and shape, differing
+only in what value is reported:
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - File
+     - Description
+   * - ``tab1_rate.csv``
+     - the hospitalization rate per 100 000 people. This is the file used to calibrate the
+       exacerbation model (see below).
+   * - ``tab1_count.csv``
+     - the number of people hospitalized with asthma.
+   * - ``tab1_N.csv``
+     - the total number of people in the category (the denominator used to compute the rate).
+   * - ``tab1_lower.csv``
+     - the lower error bar for the hospitalization rate.
+   * - ``tab1_upper.csv``
+     - the upper error bar for the hospitalization rate.
+
+Each province subfolder also contains a ``los.csv`` file with length-of-stay statistics
+(``avg``, ``med``, ``q1``, ``q3``) by ``fiscal_year``, ``age_group``, and ``sex``. This dataset
+is not currently used by the exacerbation model.
+
+``tab1_rate.csv`` Columns
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The hospitalization rate in this table is the hospitalization rate per 100 000 people.
-For example, in the category ``F_90+``, the value would be the number of people hospitalized who
+For example, in the category ``F_90+``, the value would be the rate for people hospitalized who
 are female and over 90 during the given year. This can be calculated:
 
 .. math::
-        
+
     \text{rate} = \dfrac{\text{count}}{N} \times 100000
 
 
@@ -112,7 +153,7 @@ are female and over 90 during the given year. This can be calculated:
    * - Column
      - Type
      - Description
-   * - ``fiscalYear``
+   * - ``fiscal_year``
      - :code:`int`
      - the year the data was collected
    * - ``N``
@@ -158,6 +199,20 @@ are female and over 90 during the given year. This can be calculated:
      - :code:`float`
      - the rate for all males aged over 90 in that year.
 
+The calibration step only uses the per-sex, per-age columns (``F_0`` ... ``F_90+`` and
+``M_0`` ... ``M_90+``); the sex- and age-aggregated columns (``N``, ``M``, ``F``, ``0`` ... ``90+``)
+are not used.
+
+Province Coverage
+^^^^^^^^^^^^^^^^^^
+
+Although hospitalization data is available for every province/territory listed above,
+calibration is currently only implemented for ``BC`` and ``CA`` (see
+`leap/data_generation/exacerbation_data.py
+<https://github.com/resplab/leap/blob/main/leap/data_generation/exacerbation_data.py>`_).
+The resulting ``exacerbation_calibration.csv`` used at runtime therefore only contains
+calibration multipliers for these two regions.
+
 
 
 Model
@@ -171,9 +226,11 @@ The formula is:
     N_{\text{exacerbations}} \sim \text{Poisson}(\lambda) = \dfrac{\lambda^k e^{-\lambda}}{k!}
 
 
-Here :math:`\lambda` is the expected number of exacerbations per time interval. To obtain
-:math:`\lambda`, we must perform a Poisson regression. The Poisson regression assumes that the value
-we are interested in can be approximated using the following formula:
+Here :math:`\lambda` is the expected number of exacerbations per time interval, and :math:`k` is
+the number of exacerbations (a non-negative integer) for which we are computing the
+probability. To obtain :math:`\lambda`, we must perform a Poisson regression. The Poisson
+regression assumes that the value we are interested in can be approximated using the following
+formula:
 
 .. math::
 
@@ -197,9 +254,10 @@ where:
    * - :math:`\beta_i`
      - control level constant calculated from the :ref:`Control Model <control-model>`
 
-To calculate the :math:`\beta_i` values, we consider the discrete random variable :math:`S`, which
-is the severity of an asthma exacerbation, and the continuous random variable :math:`R`, which is
-the rate of exacerbations per time interval.
+This gives us the rate :math:`\lambda` of exacerbations of *any* severity. Once an individual's
+total number of exacerbations for a time interval is drawn from this Poisson model, each
+exacerbation is further assigned a severity level (mild, moderate, severe, or very severe) — see
+:ref:`exacerbation_severity_model` below.
 
 Calibration
 ******************
@@ -224,18 +282,57 @@ Poisson regression, with the following formula:
 * :math:`c_i`: relative time spent in control level :math:`i`
 * :math:`\beta_i`: control level constant
 
-Here, the :math:`\beta_i` values were calculated from the
-`Economic Burden of Asthma (EBA) study <https://bmjopen.bmj.com/content/3/9/e003360.long>`_
-and are given by:
+The :math:`\beta_i` values are derived by combining two literature sources, as described in
+:cite:`leap2024`:
+
+* the `Economic Burden of Asthma (EBA) study <https://bmjopen.bmj.com/content/3/9/e003360.long>`_
+  (Chen et al. 2013) — a prospective, representative observational study of 618 participants aged
+  1-85 years (74% aged 18 or older) with self-reported, physician-diagnosed asthma from BC, in
+  which asthma control and the number of exacerbations were measured every 3 months over a year.
+  EBA gives us the overall mean annual exacerbation rate for a person with asthma,
+  :math:`r = 0.347`, and the proportion of time patients spend in each control level:
+  well-controlled = 0.340, partially-controlled = 0.474, uncontrolled = 0.186.
+* the `GOAL Study <https://www.atsjournals.org/doi/full/10.1164/rccm.200401-033OC>`_
+  (Bateman et al. 2004) — a one-year, randomized, double-blind clinical trial of 3,421
+  participants aged 12-80 years with uncontrolled asthma at study entry, with asthma
+  exacerbations as the primary outcome. An analysis of the GOAL data gives rounded annual
+  exacerbation rates for each control level: well-controlled = 0.1, partially-controlled = 0.2,
+  uncontrolled = 0.3 — i.e. the partially-controlled rate is twice the well-controlled rate, and
+  the uncontrolled rate is three times the well-controlled rate.
+
+Combining these two sources was necessary because the EBA cohort, while representative, did not
+have enough exacerbation events on its own to robustly estimate a rate for each control level.
+Instead, we take only the *relative* rates from GOAL, and solve for an absolute well-controlled
+rate :math:`r_{\text{wc}}` such that the population-weighted average across the three control
+levels — using the EBA time-in-control proportions together with the GOAL rate ratios — equals
+the EBA overall rate :math:`r`:
 
 .. math::
 
-    \beta_1 &:= \ln(0.1880058) \\
-    \beta_2 &:= \ln(0.3760116) \\
-    \beta_3 &:= \ln(0.5640174) 
+    r = \text{prop}_{\text{wc}} \cdot r_{\text{wc}} + \text{prop}_{\text{pc}} \cdot (2 r_{\text{wc}})
+        + \text{prop}_{\text{uc}} \cdot (3 r_{\text{wc}})
+    \quad \Longrightarrow \quad
+    r_{\text{wc}} = \dfrac{r}{\text{prop}_{\text{wc}} + 2 \cdot \text{prop}_{\text{pc}}
+        + 3 \cdot \text{prop}_{\text{uc}}}
+
+The partially-controlled and uncontrolled rates follow directly from the GOAL ratios:
+:math:`r_{\text{pc}} = 2 r_{\text{wc}}` and :math:`r_{\text{uc}} = 3 r_{\text{wc}}`. Taking the
+natural log of each rate gives the :math:`\beta_i` values:
+
+.. math::
+
+    \beta_1 &:= \ln(r_{\text{wc}}) = \ln(0.1880058) \\
+    \beta_2 &:= \ln(r_{\text{pc}}) = \ln(0.3760116) \\
+    \beta_3 &:= \ln(r_{\text{uc}}) = \ln(0.5640174)
 
 
-The number of exacerbations predicted by the model is then:
+This part of the calibration is computed entirely from input data and closed-form formulas — it
+does not require running the agent-based simulation. :math:`N` and :math:`\eta_{\text{prev}}`
+below are read directly from the Population Data and Occurrence Data datasets described above,
+and :math:`\lambda_C` is evaluated directly from the :ref:`Control Model <control-model>` formula
+using the fixed, literature-derived control-level proportions :math:`c_i` from the EBA study,
+rather than from simulated individual control-level trajectories. The number of exacerbations
+predicted by the model is then:
 
 .. math::
 
@@ -243,7 +340,8 @@ The number of exacerbations predicted by the model is then:
     N_{\text{asthma}} &= N \cdot \eta_{\text{prev}}
 
 * :math:`N_{\text{asthma}}`: the number of people in a given time interval, age, sex with asthma
-* :math:`N`: the number of people in a given time interval, age, and sex
+* :math:`N`: the number of people in a given time interval, age, and sex, from the Population Data
+  described above
 * :math:`\eta_{\text{prev}}`: the prevalence of asthma in a given time interval, age, and sex, from
   :ref:`occurrence-model-1`
 
@@ -259,8 +357,112 @@ and number of hospitalizations is:
 * :math:`P(\text{hosp})`: the probability of hospitalization due to asthma given the patient has an
   asthma exacerbation
 
-Finally, :math:`\alpha` can be computed:
+As described in :ref:`exacerbation_severity_model` below, exacerbations are classified into four
+severity levels, where **very severe** is defined as requiring hospital admission. We treat
+:math:`P(\text{hosp})` as the proportion of all exacerbations that are very severe, taken from the
+`Symbicort Given as Needed in Mild Asthma II (SYGMA II) study
+<https://www.nejm.org/doi/10.1056/NEJMoa1715275>`_ (Bateman et al. 2018), a double-blind,
+multi-centre clinical trial of 4,176 individuals with mild asthma. SYGMA II reports the
+distribution of exacerbation severity as 49.5% mild, 19.5% moderate, 28.3% severe, and 2.6% very
+severe, giving :math:`P(\text{hosp}) = 0.026` :cite:`leap2024`.
+
+Finally, :math:`\alpha` can be computed as the ratio of the **observed** to the **predicted**
+number of hospitalizations, for a given age :math:`a`, sex :math:`s`, and year :math:`y`:
 
 .. math::
 
     \alpha(a, s, y) = \dfrac{N_{\text{hosp}}(a, s, y)}{N_{\text{hosp}}^{\text{(pred)}}(a, s, y)}
+
+where :math:`N_{\text{hosp}}(a, s, y)` is the **observed** number of hospitalizations, computed
+from the observed hospitalization rate in the Hospitalization Data described above:
+
+.. math::
+
+    N_{\text{hosp}}(a, s, y) = \dfrac{\text{hospitalization rate}(a, s, y)}{100\,000} \cdot N(a, s, y)
+
+:math:`\alpha` is computed once per province, age, sex, and year as part of data generation, and is
+looked up at simulation runtime — by province, timepoint, sex, and age — to calibrate each agent's
+:math:`\lambda`.
+
+.. _exacerbation_severity_model:
+
+Severity
+******************
+
+Each asthma exacerbation is assigned one of four severity levels, classified retrospectively by
+the level of healthcare utilization required to treat it, following the framework described by
+the Global Initiative for Asthma (GINA) :cite:`gina2023`:
+
+.. list-table::
+   :widths: 10 20 70
+   :header-rows: 1
+
+   * - Level
+     - Name
+     - Healthcare utilization
+   * - 1
+     - Mild
+     - managed with reliever medication alone
+   * - 2
+     - Moderate
+     - requires a physician visit and a prescription of oral corticosteroids (OCS)
+   * - 3
+     - Severe
+     - requires an emergency department (ED) visit
+   * - 4
+     - Very severe
+     - requires hospital admission
+
+The ``very severe`` level is the one used to compute :math:`P(\text{hosp})` and calibrate
+:math:`\alpha` in the Calibration section above, and is what the Hospitalization Data described
+earlier measures.
+
+Dirichlet-Multinomial Model
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Given the total number of exacerbations :math:`N_{\text{exacerbations}}` an individual experiences
+in a time interval (drawn from the Poisson model above), the number at each severity level is
+generated using a Dirichlet-Multinomial distribution. A preliminary probability vector across the
+four levels is first drawn from a Dirichlet distribution:
+
+.. math::
+
+    \mathbf{w}^{\text{pre}} \sim \text{Dirichlet}(\boldsymbol{\delta})
+
+where :math:`\boldsymbol{\delta} = \kappa \cdot \mathbf{p}` is the Dirichlet concentration vector,
+:math:`\mathbf{p} = (p_{\text{mild}}, p_{\text{moderate}}, p_{\text{severe}}, p_{\text{very\_severe}})
+= (0.495, 0.195, 0.283, 0.026)` are the same SYGMA II severity proportions used for
+:math:`P(\text{hosp})` above :cite:`leap2024`, and :math:`\kappa = 100` is a concentration
+multiplier controlling how tightly an individual's drawn probabilities cluster around the
+population proportions :math:`\mathbf{p}`.
+
+Adjustment for Previous Hospitalization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the individual has previously been hospitalized for an asthma exacerbation, their probability
+of a very severe exacerbation is increased, and the remaining probability mass is redistributed
+proportionally across the other three levels:
+
+.. math::
+
+    w_{\text{very\_severe}} &= w^{\text{pre}}_{\text{very\_severe}} \cdot \beta_{\text{prev\_hosp}} \\
+    w_j &= \dfrac{w^{\text{pre}}_j}{\sum_{l \,\in\, \{\text{mild, moderate, severe}\}} w^{\text{pre}}_l}
+        \cdot (1 - w_{\text{very\_severe}}), \quad j \in \{\text{mild, moderate, severe}\}
+
+where :math:`\beta_{\text{prev\_hosp}}` is :math:`\beta_{\text{prev\_hosp,ped}} = 1.79` for
+individuals under 14 years of age, or :math:`\beta_{\text{prev\_hosp,adult}} = 2.88` for
+individuals 14 years of age or older. If the individual has no prior hospitalization,
+:math:`\mathbf{w} = \mathbf{w}^{\text{pre}}`.
+
+This raises the question of how "previously hospitalized" is determined for an agent whose
+asthma history was not directly simulated cycle-by-cycle — for example, an agent assigned an
+asthma label and a diagnosis age all at once when they enter the simulation. See
+:ref:`step-4-check-hospitalizations` for how this is initialized in that case.
+
+Finally, the number of exacerbations at each severity level is drawn from a Multinomial
+distribution, using :math:`N_{\text{exacerbations}}` as the number of trials:
+
+.. math::
+
+    (n_{\text{mild}}, n_{\text{moderate}}, n_{\text{severe}}, n_{\text{very\_severe}})
+        \sim \text{Multinomial}(N_{\text{exacerbations}}, \mathbf{w})

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -294,6 +294,8 @@ total number of exacerbations for a time interval is drawn from this Poisson mod
 exacerbation is further assigned a severity level (mild, moderate, severe, or very severe) — see
 :ref:`exacerbation_severity_model` below.
 
+.. _exacerbation-calibration:
+
 Calibration
 ******************
 
@@ -317,8 +319,10 @@ Poisson regression, with the following formula:
   :math:`a` and sex :math:`s` — note this has no timepoint argument, since the
   :ref:`Control Model <control-model>` assumes control level probabilities do not vary by
   calendar year
-* :math:`c_i`: the age- and sex-specific control level probability predicted by the
-  :ref:`Control Model <control-model>`'s ordinal regression
+* :math:`c_i`: the age- and sex-specific probability of control level :math:`i`,
+  :math:`P(y^{(i)} = k)`, from the :ref:`Control Model <control-model>`'s ordinal regression —
+  obtained by differencing consecutive cumulative probabilities,
+  :math:`P(y^{(i)} = k) = P(y^{(i)} \leq k) - P(y^{(i)} \leq k-1)`
 * :math:`\beta_i`: control level constant, derived below from the EBA and GOAL studies
 
 The :math:`\beta_i` values are derived by combining two literature sources, as described in
@@ -415,6 +419,25 @@ number of hospitalizations, for a given age :math:`a`, sex :math:`s`, and timepo
 where :math:`N_{\text{hosp}}(a, s, t)` is the **observed** number of hospitalizations, determined
 from the observed hospitalization rate as described in :ref:`tab1-rate-columns` above.
 
+Although :math:`\alpha` is computed from hospitalizations alone, it is applied to :math:`\lambda`,
+the rate of exacerbations of *any* severity — this is valid because :math:`P(\text{hosp})` is
+treated as a fixed constant, independent of age, sex, province, and timepoint. Substituting
+:math:`N_{\text{hosp}}^{\text{(pred)}} = N_{\text{exac}}^{\text{(pred)}} \cdot P(\text{hosp})`, and
+writing the *observed* hospitalizations as the *true* total number of exacerbations times that
+same constant, :math:`N_{\text{hosp}} = N_{\text{exac}}^{\text{(true)}} \cdot P(\text{hosp})`, the
+:math:`P(\text{hosp})` terms cancel:
+
+.. math::
+
+    \alpha = \dfrac{N_{\text{hosp}}}{N_{\text{hosp}}^{\text{(pred)}}}
+        = \dfrac{N_{\text{exac}}^{\text{(true)}} \cdot P(\text{hosp})}
+            {N_{\text{exac}}^{\text{(pred)}} \cdot P(\text{hosp})}
+        = \dfrac{N_{\text{exac}}^{\text{(true)}}}{N_{\text{exac}}^{\text{(pred)}}}
+
+So :math:`\alpha` computed from the hospitalization ratio is algebraically identical to the ratio
+of true to predicted *total* exacerbations, provided :math:`P(\text{hosp})` is indeed constant by age, sex, province, and timepoint (otherwise variation in :math:`P(\text{hosp})` would be attributed to :math:`\alpha`). Hospitalizations are used to compute it — rather than
+total exacerbations directly — because they are captured completely in CIHI's national data, stratified by age/sex/province/year.
+
 :math:`\alpha` is computed once per province, age, sex, and timepoint as part of data generation,
 and saved as:
 `processed_data/{time_delta_tag}/exacerbation_calibration.csv
@@ -495,11 +518,22 @@ four levels is first drawn from a Dirichlet distribution:
 
     \mathbf{w}^{\text{pre}} \sim \text{Dirichlet}(\boldsymbol{\delta})
 
-where :math:`\boldsymbol{\delta} = \kappa \cdot \mathbf{p}` is the Dirichlet concentration vector,
-:math:`\mathbf{p} = (p_{\text{mild}}, p_{\text{moderate}}, p_{\text{severe}}, p_{\text{very\_severe}})
+:math:`\mathbf{w}^{\text{pre}} = (w^{\text{pre}}_{\text{mild}}, w^{\text{pre}}_{\text{moderate}},
+w^{\text{pre}}_{\text{severe}}, w^{\text{pre}}_{\text{very severe}})` is a length-4 vector of
+*probabilities* (summing to 1) giving this individual's personal probability of each severity
+level. For each agent with asthma, :math:`\mathbf{w}^{\text{pre}}` is sampled once, independently
+per agent, and held fixed for their simulated lifetime — representing individual heterogeneity in
+exacerbation severity, distinct from (and prior to) the adjustment for previous hospitalization
+described below. The actual exacerbation counts are determined later using
+:math:`N_{\text{exacerbations}}` (the total count, from the Poisson model above) together with
+this probability vector.
+
+:math:`\boldsymbol{\delta} = \kappa \cdot \mathbf{p}` is the Dirichlet concentration vector,
+:math:`\mathbf{p} = (p_{\text{mild}}, p_{\text{moderate}}, p_{\text{severe}}, p_{\text{very severe}})
 = (0.495, 0.195, 0.283, 0.026)` are the same SYGMA II severity proportions used for
-:math:`P(\text{hosp})` above :cite:`leap2024`, and :math:`\kappa = 100` is a concentration
-multiplier controlling how tightly an individual's drawn probabilities cluster around the
+:math:`P(\text{hosp})` in the :ref:`Calibration <exacerbation-calibration>` section above
+:cite:`leap2024`, and :math:`\kappa = 100` is an assumed concentration
+multiplier controlling how tightly an individual's probabilities cluster around the
 population proportions :math:`\mathbf{p}`.
 
 Adjustment for Previous Hospitalization
@@ -511,14 +545,34 @@ proportionally across the other three levels:
 
 .. math::
 
-    w_{\text{very\_severe}} &= w^{\text{pre}}_{\text{very\_severe}} \cdot \beta_{\text{prev\_hosp}} \\
+    w_{\text{very severe}} &= w^{\text{pre}}_{\text{very severe}} \cdot \beta_{\text{prev hosp}} \\
     w_j &= \dfrac{w^{\text{pre}}_j}{\sum_{l \,\in\, \{\text{mild, moderate, severe}\}} w^{\text{pre}}_l}
-        \cdot (1 - w_{\text{very\_severe}}), \quad j \in \{\text{mild, moderate, severe}\}
+        \cdot (1 - w_{\text{very severe}}), \quad j \in \{\text{mild, moderate, severe}\}
 
-where :math:`\beta_{\text{prev\_hosp}}` is :math:`\beta_{\text{prev\_hosp,ped}} = 1.79` for
-individuals under 14 years of age, or :math:`\beta_{\text{prev\_hosp,adult}} = 2.88` for
-individuals 14 years of age or older. If the individual has no prior hospitalization,
-:math:`\mathbf{w} = \mathbf{w}^{\text{pre}}`.
+where:
+
+* :math:`j \in \{\text{mild, moderate, severe}\}`: this equation applies separately to each of
+  these three levels
+* :math:`l \in \{\text{mild, moderate, severe}\}`: a dummy index used only for the summation in
+  the denominator
+* :math:`\beta_{\text{prev hosp}}`: :math:`\beta_{\text{prev hosp,pediatric}} = 1.79` for
+  individuals under 14 years of age, or :math:`\beta_{\text{prev hosp,adult}} = 2.88` for
+  individuals 14 years of age or older.
+
+These rate multipliers are taken from a Canadian cohort study of the long-term natural history of
+severe asthma exacerbations :cite:`lee2022natural`, which found that a first follow-up severe
+exacerbation was associated with a 79% increase (rate multiplier 1.79, 95% CI 1.11–2.89) in the
+rate of subsequent exacerbations for pediatric patients, and a 188% increase (rate multiplier
+2.88, 95% CI 1.35–5.15) for adult patients.
+
+If the individual has no prior hospitalization, :math:`\mathbf{w} = \mathbf{w}^{\text{pre}}`.
+
+Since :math:`\mathbf{w}^{\text{pre}}` already sums to 1, inflating :math:`w_{\text{very severe}}`
+by :math:`\beta_{\text{prev hosp}}` alone would push the total above 1. The :math:`w_j` formula
+corrects this: it proportionally shrinks the mild/moderate/severe probabilities so the full
+vector :math:`\mathbf{w}` sums back to 1, while keeping their relative proportions to each other
+unchanged from :math:`\mathbf{w}^{\text{pre}}`.
+
 
 This raises the question of how "previously hospitalized" is determined for an agent whose
 asthma history was not directly simulated cycle-by-cycle — for example, an agent assigned an
@@ -530,5 +584,5 @@ distribution, using :math:`N_{\text{exacerbations}}` as the number of trials:
 
 .. math::
 
-    (n_{\text{mild}}, n_{\text{moderate}}, n_{\text{severe}}, n_{\text{very\_severe}})
+    (n_{\text{mild}}, n_{\text{moderate}}, n_{\text{severe}}, n_{\text{very severe}})
         \sim \text{Multinomial}(N_{\text{exacerbations}}, \mathbf{w})

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -360,14 +360,14 @@ Poisson regression, with the following formula:
   calendar year
 * :math:`c_k`: the age- and sex-specific probability of control level :math:`k`,
   :math:`P(y^{(i)} = k)`, from the :ref:`Control Model <control-model>`'s ordinal regression —
-  obtained by differencing consecutive cumulative probabilities,
+  obtained by subtracting consecutive cumulative probabilities,
   :math:`P(y^{(i)} = k) = P(y^{(i)} \leq k) - P(y^{(i)} \leq k-1)`
 * :math:`\beta_k`: control level constant, derived below from the EBA and GOAL studies
 
 The :math:`\beta_k` values are derived by combining two literature sources, as described in
 :cite:`leap2024`:
 
-* the `Economic Burden of Asthma (EBA) study <https://bmjopen.bmj.com/content/3/9/e003360.long>`_
+* `Economic Burden of Asthma (EBA) study <https://bmjopen.bmj.com/content/3/9/e003360.long>`_
   (Chen et al. 2013) — a prospective, representative observational study of 618 participants aged
   1-85 years (74% aged 18 or older) with self-reported, physician-diagnosed asthma from BC, in
   which asthma control and the number of exacerbations were measured every 3 months over a year.
@@ -376,8 +376,8 @@ The :math:`\beta_k` values are derived by combining two literature sources, as d
   control level over the study period: :math:`\text{prop}_{\text{wc}} = 0.340` (well-controlled),
   :math:`\text{prop}_{\text{pc}} = 0.474` (partially-controlled), and
   :math:`\text{prop}_{\text{uc}} = 0.186` (uncontrolled).
-* the `GOAL Study <https://doi.org/10.1164/rccm.200401-033OC>`_
-  (Bateman et al. 2004) — a one-year, randomized, double-blind clinical trial of 3,421
+* `GOAL Study <https://doi.org/10.1164/rccm.200401-033OC>`_
+  (Bateman et al. 2004) — a one-year, randomized, double-blind clinical trial of 3421
   participants aged 12-80 years with uncontrolled asthma at study entry, with asthma
   exacerbations as the primary outcome. An analysis of the GOAL data gives rounded annual
   exacerbation rates for each control level: well-controlled = 0.1, partially-controlled = 0.2,
@@ -442,7 +442,7 @@ severity levels, where **very severe** is defined as requiring hospital admissio
 :math:`P(\text{hosp})` as the proportion of all exacerbations that are very severe, taken from the
 `Symbicort Given as Needed in Mild Asthma II (SYGMA II) study
 <https://www.nejm.org/doi/10.1056/NEJMoa1715275>`_ (Bateman et al. 2018), a double-blind,
-multi-centre clinical trial of 4,176 individuals with mild asthma. SYGMA II reports the
+multi-centre clinical trial of 4176 individuals with mild asthma. SYGMA II reports the
 distribution of exacerbation severity as 49.5% mild, 19.5% moderate, 28.3% severe, and 2.6% very
 severe, giving :math:`P(\text{hosp}) = 0.026` :cite:`leap2024`.
 

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -126,29 +126,11 @@ with one subfolder per province/territory: ``AB``, ``BC``, ``MB``, ``NB``, ``NL`
   each of these territories individually has too few cases to report reliably.
 
 Each province subfolder contains 5 files that share the same columns and shape, differing
-only in what value is reported:
-
-.. list-table::
-   :widths: 25 75
-   :header-rows: 1
-
-   * - File
-     - Description
-   * - ``tab1_rate.csv``
-     - the hospitalization rate per 100 000 people. This is the file used to calibrate the
-       exacerbation model (see below).
-   * - ``tab1_count.csv``
-     - the number of people hospitalized with asthma.
-   * - ``tab1_N.csv``
-     - the total number of people in the category (the denominator used to compute the rate).
-   * - ``tab1_lower.csv``
-     - the lower error bar for the hospitalization rate.
-   * - ``tab1_upper.csv``
-     - the upper error bar for the hospitalization rate.
-
-Each province subfolder also contains a ``los.csv`` file with length-of-stay statistics
-(``avg``, ``med``, ``q1``, ``q3``) by ``fiscal_year``, ``age_group``, and ``sex``. This dataset
-is not currently used by the exacerbation model.
+only in what value is reported. Of these, only ``tab1_rate.csv`` (the hospitalization rate per
+100 000 people) is used to calibrate the exacerbation model (see below); the remaining 4 files
+(``tab1_count.csv``, ``tab1_N.csv``, ``tab1_lower.csv``, ``tab1_upper.csv``) and the
+per-province ``los.csv`` file are documented in :ref:`exacerbation-raw-data-files` in the
+Developers section.
 
 .. _tab1-rate-columns:
 

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -13,6 +13,8 @@ Population Data
 We use the Statistics Canada population data that was generated and saved as:
 `processed_data/{time_delta_tag}/birth/initial_population.csv
 <https://github.com/resplab/leap/blob/main/leap/processed_data/time_delta_365/birth/initial_population.csv>`_.
+This file is produced by the same data-generation script as ``birth_estimate.csv`` — see
+:ref:`birth-model` for details on how it is generated from Statistics Canada population data.
 
 
 .. list-table::
@@ -207,7 +209,8 @@ Province Coverage
 ^^^^^^^^^^^^^^^^^^
 
 Although hospitalization data is available for every province/territory listed above,
-calibration is currently only implemented for ``BC`` and ``CA`` (see
+calibration is currently only implemented for ``BC`` and ``CA``using the corresponding
+``tab1_rate.csv``file (see
 `leap/data_generation/exacerbation_data.py
 <https://github.com/resplab/leap/blob/main/leap/data_generation/exacerbation_data.py>`_).
 The resulting ``exacerbation_calibration.csv`` used at runtime therefore only contains
@@ -234,7 +237,7 @@ formula:
 
 .. math::
 
-    \ln(\lambda) = \ln(\alpha) + \beta_0 + \sum_{i=1}^3 \beta_i c_i 
+    \ln(\lambda) = \ln(\alpha) + \beta_0^{(i)} + \sum_{i=1}^3 \beta_i c_i
 
 
 where:
@@ -247,12 +250,21 @@ where:
      - Description
    * - :math:`\alpha`
      - the calibration multiplier that adjusts the model to match the hospitalization data
-   * - :math:`\beta_0`
-     - a constant randomly chosen from the normal distribution :math:`\mathcal{N}(0, 1)`
+   * - :math:`\beta_0^{(i)}`
+     - patient-specific random effect; :math:`\beta_0^{(i)} \sim \mathcal{N}(\beta_{0,\mu}, \beta_{0,\sigma}^2)`
+       (see :ref:`control-model` for the same random-effect construction used there)
    * - :math:`c_i`
      - relative time spent in control level :math:`i`
    * - :math:`\beta_i`
      - control level constant calculated from the :ref:`Control Model <control-model>`
+
+For each agent with asthma, :math:`\beta_0^{(i)}` is sampled once from
+:math:`\mathcal{N}(\beta_{0,\mu}, \beta_{0,\sigma}^2)` and held fixed for their simulated
+lifetime, representing individual heterogeneity in exacerbation risk beyond what is explained by
+age, sex, control level, and the population-level calibration :math:`\alpha`. The hyperparameters
+:math:`\beta_{0,\mu}` and :math:`\beta_{0,\sigma}` are configuration-dependent; in the current
+default configuration they are set to approximately :math:`\mathcal{N}(0, 0)`, effectively
+disabling this source of individual variation.
 
 This gives us the rate :math:`\lambda` of exacerbations of *any* severity. Once an individual's
 total number of exacerbations for a time interval is drawn from this Poisson model, each
@@ -267,7 +279,7 @@ We are interested in calculating :math:`\alpha`. If we rewrite the equation, the
 
 .. math::
 
-    \lambda = \alpha \cdot e^{\beta_0} \prod_{i=1}^3 e^{\beta_i c_i} 
+    \lambda = \alpha \cdot e^{\beta_0^{(i)}} \prod_{i=1}^3 e^{\beta_i c_i}
 
 
 How do we obtain :math:`\alpha`? We again assume that the mean value has the same form as in a

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -25,7 +25,7 @@ This file is produced by the same data-generation script as ``birth_estimate.csv
      - Type
      - Description
    * - ``timepoint``
-     - :code:`int`
+     - :code:`datetime`
      - the starting date / time of the time interval that the data applies to
    * - ``age``
      - :code:`int`
@@ -53,6 +53,18 @@ This file is produced by the same data-generation script as ``birth_estimate.csv
      - :code:`str`
      - the projection scenario used to generate the data
 
+This dataset has no ``sex`` column, so wherever a sex-specific population count
+:math:`N(a, s, t)` is needed elsewhere in this document, it is derived from age :math:`a` and
+timepoint :math:`t`'s ``n_age`` and ``prop_male`` values:
+
+.. math::
+
+    N(a, \text{M}, t) &= n_{\text{age}} \cdot p_{\text{male}} \\
+    N(a, \text{F}, t) &= n_{\text{age}} \cdot (1 - p_{\text{male}})
+
+where :math:`n_{\text{age}}` and :math:`p_{\text{male}}` are the ``n_age`` and ``prop_male``
+columns respectively.
+
 
 Occurrence Data
 ******************
@@ -72,8 +84,8 @@ See :ref:`occurrence-model-1` for more details about this dataset.
      - Type
      - Description
    * - ``timepoint``
-     - :code:`int`
-     - the starting date / time of the time interval that the data applies to
+     - :code:`datetime`
+     - The start of the time interval, e.g. 2024-01-01
    * - ``sex``
      - :code:`str`
      - ``F`` = female, ``M`` = male
@@ -136,17 +148,10 @@ Each province subfolder also contains a ``los.csv`` file with length-of-stay sta
 (``avg``, ``med``, ``q1``, ``q3``) by ``fiscal_year``, ``age_group``, and ``sex``. This dataset
 is not currently used by the exacerbation model.
 
+.. _tab1-rate-columns:
+
 ``tab1_rate.csv`` Columns
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The hospitalization rate in this table is the hospitalization rate per 100 000 people.
-For example, in the category ``F_90+``, the value would be the rate for people hospitalized who
-are female and over 90 during the given year. This can be calculated:
-
-.. math::
-
-    \text{rate} = \dfrac{\text{count}}{N} \times 100000
-
 
 .. list-table::
    :widths: 25 25 50
@@ -201,16 +206,35 @@ are female and over 90 during the given year. This can be calculated:
      - :code:`float`
      - the rate for all males aged over 90 in that year.
 
+The hospitalization rate in this table is the hospitalization rate per 100 000 people.
+For example, in the category ``F_90+``, the value would be the rate for people hospitalized who
+are female and over 90 during the given year. This can be calculated:
+
+.. math::
+
+    \text{hospitalization rate} = \dfrac{\text{count}}{N} \times 100000
+
+Therefore, the observed number of hospitalizations for a given age :math:`a`, sex :math:`s`, and
+timepoint :math:`t` can be recovered from the rate:
+
+.. math::
+
+    N_{\text{hosp}}(a, s, t) = \dfrac{\text{hospitalization rate}(a, s, t)}{100\,000} \cdot N(a, s, t)
+
+This is used to calibrate :math:`\alpha` below.
+
 The calibration step only uses the per-sex, per-age columns (``F_0`` ... ``F_90+`` and
 ``M_0`` ... ``M_90+``); the sex- and age-aggregated columns (``N``, ``M``, ``F``, ``0`` ... ``90+``)
 are not used.
+
+.. _province-coverage:
 
 Province Coverage
 ^^^^^^^^^^^^^^^^^^
 
 Although hospitalization data is available for every province/territory listed above,
-calibration is currently only implemented for ``BC`` and ``CA``using the corresponding
-``tab1_rate.csv``file (see
+calibration is currently only implemented for ``BC`` and ``CA`` using the corresponding
+``tab1_rate.csv`` file (see
 `leap/data_generation/exacerbation_data.py
 <https://github.com/resplab/leap/blob/main/leap/data_generation/exacerbation_data.py>`_).
 The resulting ``exacerbation_calibration.csv`` used at runtime therefore only contains
@@ -251,20 +275,19 @@ where:
    * - :math:`\alpha`
      - the calibration multiplier that adjusts the model to match the hospitalization data
    * - :math:`\beta_0^{(i)}`
-     - patient-specific random effect; :math:`\beta_0^{(i)} \sim \mathcal{N}(\beta_{0,\mu}, \beta_{0,\sigma}^2)`
-       (see :ref:`control-model` for the same random-effect construction used there)
+     - patient-specific random effect; :math:`\beta_0^{(i)} \sim \mathcal{N}(0, \sigma^2)`
    * - :math:`c_i`
-     - relative time spent in control level :math:`i`
+     - relative time spent in control level :math:`i`, given by the probability of control level
+       :math:`i` from the :ref:`Control Model <control-model>`
    * - :math:`\beta_i`
-     - control level constant calculated from the :ref:`Control Model <control-model>`
+     - control level constant, derived from the EBA and GOAL studies (see Calibration below)
 
-For each agent with asthma, :math:`\beta_0^{(i)}` is sampled once from
-:math:`\mathcal{N}(\beta_{0,\mu}, \beta_{0,\sigma}^2)` and held fixed for their simulated
-lifetime, representing individual heterogeneity in exacerbation risk beyond what is explained by
-age, sex, control level, and the population-level calibration :math:`\alpha`. The hyperparameters
-:math:`\beta_{0,\mu}` and :math:`\beta_{0,\sigma}` are configuration-dependent; in the current
-default configuration they are set to approximately :math:`\mathcal{N}(0, 0)`, effectively
-disabling this source of individual variation.
+For each agent with asthma, :math:`\beta_0^{(i)}` is sampled once and held fixed for their
+simulated lifetime, representing individual heterogeneity in exacerbation risk beyond what is
+explained by age, sex, control level, and the population-level calibration :math:`\alpha`. The
+mean and variance of this distribution are configuration-dependent; in the current default
+configuration they are set to approximately :math:`\mathcal{N}(0, 0)`, effectively disabling this
+source of individual variation.
 
 This gives us the rate :math:`\lambda` of exacerbations of *any* severity. Once an individual's
 total number of exacerbations for a time interval is drawn from this Poisson model, each
@@ -287,12 +310,16 @@ Poisson regression, with the following formula:
 
 .. math::
 
-    \ln(\lambda_{C}) = \sum_{i=1}^3 \beta_i c_i 
+    \ln(\lambda_{C}(a, s)) = \sum_{i=1}^3 \beta_i c_i
 
 
-* :math:`\lambda_C`: the average number of exacerbations in a given time interval
-* :math:`c_i`: relative time spent in control level :math:`i`
-* :math:`\beta_i`: control level constant
+* :math:`\lambda_C(a, s)`: the predicted mean number of exacerbations per year for a given age
+  :math:`a` and sex :math:`s` — note this has no timepoint argument, since the
+  :ref:`Control Model <control-model>` assumes control level probabilities do not vary by
+  calendar year
+* :math:`c_i`: the age- and sex-specific control level probability predicted by the
+  :ref:`Control Model <control-model>`'s ordinal regression
+* :math:`\beta_i`: control level constant, derived below from the EBA and GOAL studies
 
 The :math:`\beta_i` values are derived by combining two literature sources, as described in
 :cite:`leap2024`:
@@ -302,9 +329,13 @@ The :math:`\beta_i` values are derived by combining two literature sources, as d
   1-85 years (74% aged 18 or older) with self-reported, physician-diagnosed asthma from BC, in
   which asthma control and the number of exacerbations were measured every 3 months over a year.
   EBA gives us the overall mean annual exacerbation rate for a person with asthma,
-  :math:`r = 0.347`, and the proportion of time patients spend in each control level:
-  well-controlled = 0.340, partially-controlled = 0.474, uncontrolled = 0.186.
-* the `GOAL Study <https://www.atsjournals.org/doi/full/10.1164/rccm.200401-033OC>`_
+  :math:`r = 0.347`, and the overall proportion of time the EBA cohort as a whole spent in each
+  control level over the study period: :math:`\text{prop}_{\text{wc}} = 0.340` (well-controlled),
+  :math:`\text{prop}_{\text{pc}} = 0.474` (partially-controlled), and
+  :math:`\text{prop}_{\text{uc}} = 0.186` (uncontrolled). These are fixed, EBA-cohort-wide
+  averages used only to derive the :math:`\beta_i` values below — a different quantity from the
+  per-agent, age- and sex-specific :math:`c_i` used elsewhere in this model.
+* the `GOAL Study <https://doi.org/10.1164/rccm.200401-033OC>`_
   (Bateman et al. 2004) — a one-year, randomized, double-blind clinical trial of 3,421
   participants aged 12-80 years with uncontrolled asthma at study entry, with asthma
   exacerbations as the primary outcome. An analysis of the GOAL data gives rounded annual
@@ -338,36 +369,32 @@ natural log of each rate gives the :math:`\beta_i` values:
     \beta_3 &:= \ln(r_{\text{uc}}) = \ln(0.5640174)
 
 
-This part of the calibration is computed entirely from input data and closed-form formulas — it
-does not require running the agent-based simulation. :math:`N` and :math:`\eta_{\text{prev}}`
-below are read directly from the Population Data and Occurrence Data datasets described above,
-and :math:`\lambda_C` is evaluated directly from the :ref:`Control Model <control-model>` formula
-using the fixed, literature-derived control-level proportions :math:`c_i` from the EBA study,
-rather than from simulated individual control-level trajectories. The number of exacerbations
-predicted by the model is then:
+The number of exacerbations predicted by the model is then:
 
 .. math::
 
-    N_{\text{exac}}^{\text{(pred)}} &= \lambda_C \cdot N_{\text{asthma}} \\
-    N_{\text{asthma}} &= N \cdot \eta_{\text{prev}}
+    N_{\text{asthma}}(a, s, t) &= N(a, s, t) \cdot \eta_{\text{prev}}(a, s, t) \\
+    N_{\text{exac}}^{\text{(pred)}}(a, s, t) &= \lambda_C(a, s) \cdot N_{\text{asthma}}(a, s, t) \\
 
-* :math:`N_{\text{asthma}}`: the number of people in a given time interval, age, sex with asthma
-* :math:`N`: the number of people in a given time interval, age, and sex, from the Population Data
-  described above
-* :math:`\eta_{\text{prev}}`: the prevalence of asthma in a given time interval, age, and sex, from
-  :ref:`occurrence-model-1`
+* :math:`N_{\text{asthma}}(a, s, t)`: the number of people of age :math:`a`, sex :math:`s`, at
+  timepoint :math:`t` with asthma
+* :math:`N(a, s, t)`: the number of people of age :math:`a`, sex :math:`s`, at timepoint :math:`t`,
+  from the Population Data described above
+* :math:`\eta_{\text{prev}}(a, s, t)`: the prevalence of asthma for age :math:`a`, sex :math:`s`,
+  at timepoint :math:`t`, from :ref:`occurrence-model-1`
+* :math:`\lambda_C(a, s)`: as defined above
 
 and number of hospitalizations is:
 
 .. math::
 
-    N_{\text{hosp}}^{\text{(pred)}} = N_{\text{exac}}^{\text{(pred)}} \cdot P(\text{hosp})
+    N_{\text{hosp}}^{\text{(pred)}}(a, s, t) = N_{\text{exac}}^{\text{(pred)}}(a, s, t) \cdot P(\text{hosp})
 
 
-* :math:`N_{\text{exac}}^{\text{(pred)}}`: the predicted number of exacerbations (of any severity)
-  for a given time interval, age, and sex
+* :math:`N_{\text{exac}}^{\text{(pred)}}(a, s, t)`: the predicted number of exacerbations (of any
+  severity) for age :math:`a`, sex :math:`s`, at timepoint :math:`t`
 * :math:`P(\text{hosp})`: the probability of hospitalization due to asthma given the patient has an
-  asthma exacerbation
+  asthma exacerbation (a single constant, not stratified by :math:`a`, :math:`s`, or :math:`t`)
 
 As described in :ref:`exacerbation_severity_model` below, exacerbations are classified into four
 severity levels, where **very severe** is defined as requiring hospital admission. We treat
@@ -379,22 +406,49 @@ distribution of exacerbation severity as 49.5% mild, 19.5% moderate, 28.3% sever
 severe, giving :math:`P(\text{hosp}) = 0.026` :cite:`leap2024`.
 
 Finally, :math:`\alpha` can be computed as the ratio of the **observed** to the **predicted**
-number of hospitalizations, for a given age :math:`a`, sex :math:`s`, and year :math:`y`:
+number of hospitalizations, for a given age :math:`a`, sex :math:`s`, and timepoint :math:`t`:
 
 .. math::
 
-    \alpha(a, s, y) = \dfrac{N_{\text{hosp}}(a, s, y)}{N_{\text{hosp}}^{\text{(pred)}}(a, s, y)}
+    \alpha(a, s, t) = \dfrac{N_{\text{hosp}}(a, s, t)}{N_{\text{hosp}}^{\text{(pred)}}(a, s, t)}
 
-where :math:`N_{\text{hosp}}(a, s, y)` is the **observed** number of hospitalizations, computed
-from the observed hospitalization rate in the Hospitalization Data described above:
+where :math:`N_{\text{hosp}}(a, s, t)` is the **observed** number of hospitalizations, determined
+from the observed hospitalization rate as described in :ref:`tab1-rate-columns` above.
 
-.. math::
+:math:`\alpha` is computed once per province, age, sex, and timepoint as part of data generation,
+and saved as:
+`processed_data/{time_delta_tag}/exacerbation_calibration.csv
+<https://github.com/resplab/leap/blob/main/leap/processed_data/time_delta_365/exacerbation_calibration.csv>`_.
+This file is looked up at simulation runtime — by province, timepoint, sex, and age — to
+calibrate each agent's :math:`\lambda`.
 
-    N_{\text{hosp}}(a, s, y) = \dfrac{\text{hospitalization rate}(a, s, y)}{100\,000} \cdot N(a, s, y)
+Processed Data
+^^^^^^^^^^^^^^^^
 
-:math:`\alpha` is computed once per province, age, sex, and year as part of data generation, and is
-looked up at simulation runtime — by province, timepoint, sex, and age — to calibrate each agent's
-:math:`\lambda`.
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Description
+   * - ``timepoint``
+     - :code:`datetime`
+     - The start of the time interval, e.g. 2024-01-01
+   * - ``sex``
+     - :code:`str`
+     - ``F`` = female, ``M`` = male
+   * - ``age``
+     - :code:`int`
+     - the age of the patient in years
+   * - ``province``
+     - :code:`str`
+     - the 2-letter province abbreviation (currently only ``BC`` and ``CA``, see
+       :ref:`province-coverage` above)
+   * - ``calibrator_multiplier``
+     - :code:`float`
+     - the calibration multiplier :math:`\alpha(a, s, t)` for the given age, sex, timepoint, and
+       province
 
 .. _exacerbation_severity_model:
 

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -275,7 +275,7 @@ source of individual variation.
 This gives us the rate :math:`\lambda` of exacerbations of *any* severity. Once an individual's
 total number of exacerbations for a time interval is drawn from this Poisson model, each
 exacerbation is further assigned a severity level (mild, moderate, severe, or very severe) — see
-:ref:`exacerbation_severity_model` below.
+the :ref:`exacerbation_severity_model`.
 
 The diagram below summarises how these pieces fit together conceptually, for a given age
 :math:`a` and sex :math:`s`, from calibration through to the final severity-level counts.
@@ -422,7 +422,7 @@ and number of hospitalizations is:
 * :math:`P(\text{hosp})`: the probability of hospitalization due to asthma given the patient has an
   asthma exacerbation (a single constant, not stratified by :math:`a`, :math:`s`, or :math:`t`)
 
-As described in :ref:`exacerbation_severity_model` below, exacerbations are classified into four
+As described in the :ref:`exacerbation_severity_model`, exacerbations are classified into four
 severity levels, where **very severe** is defined as requiring hospital admission. We treat
 :math:`P(\text{hosp})` as the proportion of all exacerbations that are very severe, taken from the
 `Symbicort Given as Needed in Mild Asthma II (SYGMA II) study
@@ -502,116 +502,4 @@ Processed Data
      - the calibration multiplier :math:`\alpha(a, s, t)` for the given age, sex, timepoint, and
        province
 
-.. _exacerbation_severity_model:
 
-Severity
-******************
-
-Each asthma exacerbation is assigned one of four severity levels, classified retrospectively by
-the level of healthcare utilization required to treat it, following the framework described by
-the Global Initiative for Asthma (GINA) :cite:`gina2023`:
-
-.. list-table::
-   :widths: 10 20 70
-   :header-rows: 1
-
-   * - Level
-     - Name
-     - Healthcare utilization
-   * - 1
-     - Mild
-     - managed with reliever medication alone
-   * - 2
-     - Moderate
-     - requires a physician visit and a prescription of oral corticosteroids (OCS)
-   * - 3
-     - Severe
-     - requires an emergency department (ED) visit
-   * - 4
-     - Very severe
-     - requires hospital admission
-
-The ``very severe`` level is the one used to compute :math:`P(\text{hosp})` and calibrate
-:math:`\alpha` in the Calibration section above, and is what the Hospitalization Data described
-earlier measures.
-
-Dirichlet-Multinomial Model
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Given the total number of exacerbations :math:`N_{\text{exacerbations}}` an individual experiences
-in a time interval (drawn from the Poisson model above), the number at each severity level is
-generated using a Dirichlet-Multinomial distribution. A preliminary probability vector across the
-four levels is first drawn from a Dirichlet distribution:
-
-.. math::
-
-    \mathbf{w}^{\text{pre}} \sim \text{Dirichlet}(\boldsymbol{\delta})
-
-:math:`\mathbf{w}^{\text{pre}} = (w^{\text{pre}}_{\text{mild}}, w^{\text{pre}}_{\text{moderate}},
-w^{\text{pre}}_{\text{severe}}, w^{\text{pre}}_{\text{very severe}})` is a length-4 vector of
-*probabilities* (summing to 1) giving this individual's personal probability of each severity
-level. For each agent with asthma, :math:`\mathbf{w}^{\text{pre}}` is sampled once, independently
-per agent, and held fixed for their simulated lifetime — representing individual heterogeneity in
-exacerbation severity, distinct from (and prior to) the adjustment for previous hospitalization
-described below. The actual exacerbation counts are determined later using
-:math:`N_{\text{exacerbations}}` (the total count, from the Poisson model above) together with
-this probability vector.
-
-:math:`\boldsymbol{\delta} = \kappa \cdot \mathbf{p}` is the Dirichlet concentration vector,
-:math:`\mathbf{p} = (p_{\text{mild}}, p_{\text{moderate}}, p_{\text{severe}}, p_{\text{very severe}})
-= (0.495, 0.195, 0.283, 0.026)` are the same SYGMA II severity proportions used for
-:math:`P(\text{hosp})` in the :ref:`Calibration <exacerbation-calibration>` section above
-:cite:`leap2024`, and :math:`\kappa = 100` is an assumed concentration
-multiplier controlling how tightly an individual's probabilities cluster around the
-population proportions :math:`\mathbf{p}`.
-
-Adjustment for Previous Hospitalization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If the individual has previously been hospitalized for an asthma exacerbation, their probability
-of a very severe exacerbation is increased, and the remaining probability mass is redistributed
-proportionally across the other three levels:
-
-.. math::
-
-    w_{\text{very severe}} &= w^{\text{pre}}_{\text{very severe}} \cdot \beta_{\text{prev hosp}} \\
-    w_j &= \dfrac{w^{\text{pre}}_j}{\sum_{l \,\in\, \{\text{mild, moderate, severe}\}} w^{\text{pre}}_l}
-        \cdot (1 - w_{\text{very severe}}), \quad j \in \{\text{mild, moderate, severe}\}
-
-where:
-
-* :math:`j \in \{\text{mild, moderate, severe}\}`: this equation applies separately to each of
-  these three levels
-* :math:`l \in \{\text{mild, moderate, severe}\}`: a dummy index used only for the summation in
-  the denominator
-* :math:`\beta_{\text{prev hosp}}`: :math:`\beta_{\text{prev hosp,pediatric}} = 1.79` for
-  individuals under 14 years of age, or :math:`\beta_{\text{prev hosp,adult}} = 2.88` for
-  individuals 14 years of age or older.
-
-These rate multipliers are taken from a Canadian cohort study of the long-term natural history of
-severe asthma exacerbations :cite:`lee2022natural`, which found that a first follow-up severe
-exacerbation was associated with a 79% increase (rate multiplier 1.79, 95% CI 1.11–2.89) in the
-rate of subsequent exacerbations for pediatric patients, and a 188% increase (rate multiplier
-2.88, 95% CI 1.35–5.15) for adult patients.
-
-If the individual has no prior hospitalization, :math:`\mathbf{w} = \mathbf{w}^{\text{pre}}`.
-
-Since :math:`\mathbf{w}^{\text{pre}}` already sums to 1, inflating :math:`w_{\text{very severe}}`
-by :math:`\beta_{\text{prev hosp}}` alone would push the total above 1. The :math:`w_j` formula
-corrects this: it proportionally shrinks the mild/moderate/severe probabilities so the full
-vector :math:`\mathbf{w}` sums back to 1, while keeping their relative proportions to each other
-unchanged from :math:`\mathbf{w}^{\text{pre}}`.
-
-
-This raises the question of how "previously hospitalized" is determined for an agent whose
-asthma history was not directly simulated cycle-by-cycle — for example, an agent assigned an
-asthma label and a diagnosis age all at once when they enter the simulation. See
-:ref:`step-4-check-hospitalizations` for how this is initialized in that case.
-
-Finally, the number of exacerbations at each severity level is drawn from a Multinomial
-distribution, using :math:`N_{\text{exacerbations}}` as the number of trials:
-
-.. math::
-
-    (n_{\text{mild}}, n_{\text{moderate}}, n_{\text{severe}}, n_{\text{very severe}})
-        \sim \text{Multinomial}(N_{\text{exacerbations}}, \mathbf{w})

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -292,6 +292,47 @@ total number of exacerbations for a time interval is drawn from this Poisson mod
 exacerbation is further assigned a severity level (mild, moderate, severe, or very severe) — see
 :ref:`exacerbation_severity_model` below.
 
+The diagram below summarises how these pieces fit together conceptually, for a given age
+:math:`a` and sex :math:`s`, from calibration through to the final severity-level counts.
+
+.. md-mermaid::
+
+    flowchart TD
+        ALPHA["<b>Calibration multiplier</b>&nbsp;<span style='font-size:1.3em'>$$\alpha$$</span><br/>predicted vs. observed<br/>hospitalizations in CIHI data"]
+        BI["<b>Control-level rate constants</b>&nbsp;<span style='font-size:1.3em'>$$\beta_i$$</span><br/>derived from EBA + GOAL studies"]
+        CI["<b>Control-level probabilities</b>&nbsp;<span style='font-size:1.3em'>$$c_i$$</span><br/>predicted by the Control Model"]
+
+        RATE["<b>Rate of exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$\lambda$$</span><br/>(any severity)"]
+
+        ALPHA --> RATE
+        BI --> RATE
+        CI --> RATE
+
+        COUNT["<b>Total exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$N_{\text{exacerbations}}$$</span><br/>this time interval"]
+        RATE --> COUNT
+
+        SEV["<b>Severity probabilities</b>&nbsp;<span style='font-size:1.3em'>$$\mathbf{w}$$</span><br/>based on SYGMA II<br/>severity/hospitalization proportions"]
+        HIST["<b>History of very severe</b><br/><b>exacerbations</b>&nbsp;<span style='font-size:1.3em'>$$\beta_{\text{prev hosp}}$$</span><br/>(hospitalization)"]
+        HIST -->|"increases probability<br/>of very severe"| SEV
+
+        OUTPUT["<b>Exacerbations by</b><br/><b>severity level</b>&nbsp;<span style='font-size:1.3em'>$$(n_{\text{mild}}, \ldots, n_{\text{very severe}})$$</span>"]
+        COUNT --> OUTPUT
+        SEV --> OUTPUT
+
+        classDef input fill:#fff3e0,stroke:#e65100,color:#3a2400;
+        classDef stage fill:#e3f2fd,stroke:#1565c0,color:#0d2b45;
+        classDef output fill:#e8f5e9,stroke:#2e7d32,color:#10300f;
+        class ALPHA,BI,CI,HIST input;
+        class RATE,COUNT,SEV stage;
+        class OUTPUT output;
+
+        classDef input fill:#fff3e0,stroke:#e65100,color:#3a2400;
+        classDef formula fill:#e3f2fd,stroke:#1565c0,color:#0d2b45;
+        classDef sim fill:#e8f5e9,stroke:#2e7d32,color:#10300f;
+        class ALPHA,B0,BI,CI input;
+        class FORMULA,POISSON formula;
+        class W,HIST,MULTI sim;
+
 .. _exacerbation-calibration:
 
 Calibration

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -208,11 +208,7 @@ is not currently used by the exacerbation model.
 
 The hospitalization rate in this table is the hospitalization rate per 100 000 people.
 For example, in the category ``F_90+``, the value would be the rate for people hospitalized who
-are female and over 90 during the given year. This can be calculated:
-
-.. math::
-
-    \text{hospitalization rate} = \dfrac{\text{count}}{N} \times 100000
+are female and over 90 during the given year.
 
 Therefore, the observed number of hospitalizations for a given age :math:`a`, sex :math:`s`, and
 timepoint :math:`t` can be recovered from the rate:
@@ -220,6 +216,8 @@ timepoint :math:`t` can be recovered from the rate:
 .. math::
 
     N_{\text{hosp}}(a, s, t) = \dfrac{\text{hospitalization rate}(a, s, t)}{100\,000} \cdot N(a, s, t)
+
+Here, :math:`N(a, s, t)` is the population count from the Population Data described above.
 
 This is used to calibrate :math:`\alpha` below.
 
@@ -336,9 +334,7 @@ The :math:`\beta_i` values are derived by combining two literature sources, as d
   :math:`r = 0.347`, and the overall proportion of time the EBA cohort as a whole spent in each
   control level over the study period: :math:`\text{prop}_{\text{wc}} = 0.340` (well-controlled),
   :math:`\text{prop}_{\text{pc}} = 0.474` (partially-controlled), and
-  :math:`\text{prop}_{\text{uc}} = 0.186` (uncontrolled). These are fixed, EBA-cohort-wide
-  averages used only to derive the :math:`\beta_i` values below — a different quantity from the
-  per-agent, age- and sex-specific :math:`c_i` used elsewhere in this model.
+  :math:`\text{prop}_{\text{uc}} = 0.186` (uncontrolled).
 * the `GOAL Study <https://doi.org/10.1164/rccm.200401-033OC>`_
   (Bateman et al. 2004) — a one-year, randomized, double-blind clinical trial of 3,421
   participants aged 12-80 years with uncontrolled asthma at study entry, with asthma
@@ -417,26 +413,33 @@ number of hospitalizations, for a given age :math:`a`, sex :math:`s`, and timepo
     \alpha(a, s, t) = \dfrac{N_{\text{hosp}}(a, s, t)}{N_{\text{hosp}}^{\text{(pred)}}(a, s, t)}
 
 where :math:`N_{\text{hosp}}(a, s, t)` is the **observed** number of hospitalizations, determined
-from the observed hospitalization rate as described in :ref:`tab1-rate-columns` above.
+from the observed hospitalization rate in CIHI as described in :ref:`tab1-rate-columns` above.
 
-Although :math:`\alpha` is computed from hospitalizations alone, it is applied to :math:`\lambda`,
-the rate of exacerbations of *any* severity — this is valid because :math:`P(\text{hosp})` is
-treated as a fixed constant, independent of age, sex, province, and timepoint. Substituting
-:math:`N_{\text{hosp}}^{\text{(pred)}} = N_{\text{exac}}^{\text{(pred)}} \cdot P(\text{hosp})`, and
-writing the *observed* hospitalizations as the *true* total number of exacerbations times that
-same constant, :math:`N_{\text{hosp}} = N_{\text{exac}}^{\text{(true)}} \cdot P(\text{hosp})`, the
-:math:`P(\text{hosp})` terms cancel:
+.. info:: Math: Why α (from Hospitalizations) Applies to λ (All Severities)
+  :collapsible:
 
-.. math::
+  Although :math:`\alpha` is computed from hospitalizations alone, it is applied to
+  :math:`\lambda`, the rate of exacerbations of *any* severity — this is valid because
+  :math:`P(\text{hosp})` is treated as a fixed constant, independent of age, sex, province, and
+  timepoint. Substituting
+  :math:`N_{\text{hosp}}^{\text{(pred)}} = N_{\text{exac}}^{\text{(pred)}} \cdot P(\text{hosp})`,
+  and writing the *observed* hospitalizations as the *true* total number of exacerbations times
+  that same constant, :math:`N_{\text{hosp}} = N_{\text{exac}}^{\text{(true)}} \cdot P(\text{hosp})`,
+  the :math:`P(\text{hosp})` terms cancel:
 
-    \alpha = \dfrac{N_{\text{hosp}}}{N_{\text{hosp}}^{\text{(pred)}}}
-        = \dfrac{N_{\text{exac}}^{\text{(true)}} \cdot P(\text{hosp})}
-            {N_{\text{exac}}^{\text{(pred)}} \cdot P(\text{hosp})}
-        = \dfrac{N_{\text{exac}}^{\text{(true)}}}{N_{\text{exac}}^{\text{(pred)}}}
+  .. math::
 
-So :math:`\alpha` computed from the hospitalization ratio is algebraically identical to the ratio
-of true to predicted *total* exacerbations, provided :math:`P(\text{hosp})` is indeed constant by age, sex, province, and timepoint (otherwise variation in :math:`P(\text{hosp})` would be attributed to :math:`\alpha`). Hospitalizations are used to compute it — rather than
-total exacerbations directly — because they are captured completely in CIHI's national data, stratified by age/sex/province/year.
+      \alpha = \dfrac{N_{\text{hosp}}}{N_{\text{hosp}}^{\text{(pred)}}}
+          = \dfrac{N_{\text{exac}}^{\text{(true)}} \cdot P(\text{hosp})}
+              {N_{\text{exac}}^{\text{(pred)}} \cdot P(\text{hosp})}
+          = \dfrac{N_{\text{exac}}^{\text{(true)}}}{N_{\text{exac}}^{\text{(pred)}}}
+
+  So :math:`\alpha` computed from the hospitalization ratio is algebraically identical to the
+  ratio of true to predicted *total* exacerbations, provided :math:`P(\text{hosp})` is indeed
+  constant by age, sex, province, and timepoint (otherwise variation in :math:`P(\text{hosp})`
+  would be attributed to :math:`\alpha`). Hospitalizations are used to compute it — rather than
+  total exacerbations directly — because they are captured completely in CIHI's national data,
+  stratified by age/sex/province/year.
 
 :math:`\alpha` is computed once per province, age, sex, and timepoint as part of data generation,
 and saved as:

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -7,6 +7,8 @@ Asthma Exacerbations Model
 Data
 ====
 
+.. _exacerbation-model-population-data:
+
 Population Data
 *****************
 
@@ -217,7 +219,8 @@ timepoint :math:`t` can be recovered from the rate:
 
     N_{\text{hosp}}(a, s, t) = \dfrac{\text{hospitalization rate}(a, s, t)}{100\,000} \cdot N(a, s, t)
 
-Here, :math:`N(a, s, t)` is the population count from the Population Data described above.
+Here, :math:`N(a, s, t)` is the population count from the :ref:`exacerbation-model-population-data`
+described above.
 
 This is used to calibrate :math:`\alpha` below.
 
@@ -420,7 +423,7 @@ The number of exacerbations predicted by the model is then:
 * :math:`N_{\text{asthma}}(a, s, t)`: the number of people of age :math:`a`, sex :math:`s`, at
   timepoint :math:`t` with asthma
 * :math:`N(a, s, t)`: the number of people of age :math:`a`, sex :math:`s`, at timepoint :math:`t`,
-  from the Population Data described above
+  from the :ref:`exacerbation-model-population-data` described above
 * :math:`\eta_{\text{prev}}(a, s, t)`: the prevalence of asthma for age :math:`a`, sex :math:`s`,
   at timepoint :math:`t`, from :ref:`occurrence-model-1`
 * :math:`\lambda_C(a, s)`: as defined above

--- a/docs/model/model-exacerbation.rst
+++ b/docs/model/model-exacerbation.rst
@@ -248,10 +248,10 @@ The formula is:
 
 .. math::
 
-    N_{\text{exacerbations}} \sim \text{Poisson}(\lambda) = \dfrac{\lambda^k e^{-\lambda}}{k!}
+    N_{\text{exacerbations}} \sim \text{Poisson}(\lambda) = \dfrac{\lambda^{\kappa} e^{-\lambda}}{\kappa!}
 
 
-Here :math:`\lambda` is the expected number of exacerbations per time interval, and :math:`k` is
+Here :math:`\lambda` is the expected number of exacerbations per time interval, and :math:`\kappa` is
 the number of exacerbations (a non-negative integer) for which we are computing the
 probability. To obtain :math:`\lambda`, we must perform a Poisson regression. The Poisson
 regression assumes that the value we are interested in can be approximated using the following
@@ -259,7 +259,7 @@ formula:
 
 .. math::
 
-    \ln(\lambda) = \ln(\alpha) + \beta_0^{(i)} + \sum_{i=1}^3 \beta_i c_i
+    \ln(\lambda) = \ln(\alpha) + \beta_0^{(i)} + \sum_{k=1}^3 \beta_k c_k
 
 
 where:
@@ -274,10 +274,10 @@ where:
      - the calibration multiplier that adjusts the model to match the hospitalization data
    * - :math:`\beta_0^{(i)}`
      - patient-specific random effect; :math:`\beta_0^{(i)} \sim \mathcal{N}(0, \sigma^2)`
-   * - :math:`c_i`
-     - relative time spent in control level :math:`i`, given by the probability of control level
-       :math:`i` from the :ref:`Control Model <control-model>`
-   * - :math:`\beta_i`
+   * - :math:`c_k`
+     - relative time spent in control level :math:`k`, given by the probability of control level
+       :math:`k` from the :ref:`Control Model <control-model>`
+   * - :math:`\beta_k`
      - control level constant, derived from the EBA and GOAL studies (see Calibration below)
 
 For each agent with asthma, :math:`\beta_0^{(i)}` is sampled once and held fixed for their
@@ -343,7 +343,7 @@ We are interested in calculating :math:`\alpha`. If we rewrite the equation, the
 
 .. math::
 
-    \lambda = \alpha \cdot e^{\beta_0^{(i)}} \prod_{i=1}^3 e^{\beta_i c_i}
+    \lambda = \alpha \cdot e^{\beta_0^{(i)}} \prod_{k=1}^3 e^{\beta_k c_k}
 
 
 How do we obtain :math:`\alpha`? We again assume that the mean value has the same form as in a
@@ -351,20 +351,20 @@ Poisson regression, with the following formula:
 
 .. math::
 
-    \ln(\lambda_{C}(a, s)) = \sum_{i=1}^3 \beta_i c_i
+    \ln(\lambda_{C}(a, s)) = \sum_{k=1}^3 \beta_k c_k
 
 
 * :math:`\lambda_C(a, s)`: the predicted mean number of exacerbations per year for a given age
   :math:`a` and sex :math:`s` — note this has no timepoint argument, since the
   :ref:`Control Model <control-model>` assumes control level probabilities do not vary by
   calendar year
-* :math:`c_i`: the age- and sex-specific probability of control level :math:`i`,
+* :math:`c_k`: the age- and sex-specific probability of control level :math:`k`,
   :math:`P(y^{(i)} = k)`, from the :ref:`Control Model <control-model>`'s ordinal regression —
   obtained by differencing consecutive cumulative probabilities,
   :math:`P(y^{(i)} = k) = P(y^{(i)} \leq k) - P(y^{(i)} \leq k-1)`
-* :math:`\beta_i`: control level constant, derived below from the EBA and GOAL studies
+* :math:`\beta_k`: control level constant, derived below from the EBA and GOAL studies
 
-The :math:`\beta_i` values are derived by combining two literature sources, as described in
+The :math:`\beta_k` values are derived by combining two literature sources, as described in
 :cite:`leap2024`:
 
 * the `Economic Burden of Asthma (EBA) study <https://bmjopen.bmj.com/content/3/9/e003360.long>`_
@@ -401,7 +401,7 @@ the EBA overall rate :math:`r`:
 
 The partially-controlled and uncontrolled rates follow directly from the GOAL ratios:
 :math:`r_{\text{pc}} = 2 r_{\text{wc}}` and :math:`r_{\text{uc}} = 3 r_{\text{wc}}`. Taking the
-natural log of each rate gives the :math:`\beta_i` values:
+natural log of each rate gives the :math:`\beta_k` values:
 
 .. math::
 

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -286,7 +286,7 @@ To initialize an agent, we set the following initial attributes:
      - The agent's cumulative count of very severe (hospitalized) exacerbations. For an agent with
        asthma, this is initialized via the mini-simulation described in
        :ref:`step-4-check-hospitalizations` below; otherwise it starts at 0. It is incremented
-       each subsequent time interval — see Step 8.
+       each subsequent time interval — see Step 8 and Step 6.
 
 
 Step 1: Check if the agent is over 3 years old
@@ -338,21 +338,21 @@ Since this agent's asthma history was not directly simulated cycle-by-cycle (it 
 at once in Steps 2 and 3), we cannot just look up whether a hospitalization occurred. Instead, we assume the agent's asthma was **not reversible** between their diagnosis age and
 two years before their current age: that is, we treat the agent as having had asthma
 continuously over that span. Under this assumption, we run a mini-simulation that sums the
-expected exacerbation rate :math:`\lambda` (using the Step 6 formula below, with that year's age,
-sex, and control levels) over every year from the asthma diagnosis age up to two years
-before the agent's current age:
+expected exacerbation rate :math:`\lambda^{(i)}` for this agent :math:`i` (using the Step 6
+formula below, with that year's age, sex, and control levels) over every year from the asthma
+diagnosis age up to two years before the agent's current age:
 
 .. math::
 
-    \text{total rate} = \sum_{y} \lambda_y
+    \text{total rate}^{(i)} = \sum_{y} \lambda_y^{(i)}
 
 where :math:`y` ranges over each year (not the simulation's own timepoint, but a calendar
 year) from the asthma diagnosis age up to two years before the agent's current age, and
-:math:`\lambda_y` is :math:`\lambda` evaluated at that year (Step 6 below).
+:math:`\lambda_y^{(i)}` is :math:`\lambda^{(i)}` evaluated at that year (Step 6 below).
 
 We then compute the probability that *none* of the agent's exacerbations over this span were very
 severe. Each agent's probability of a very severe exacerbation is
-:math:`w^{\text{pre}}_{\text{very severe}}` — the same pre-adjustment Dirichlet-drawn quantity
+:math:`w^{\text{pre},(i)}_{\text{very severe}}` — the same pre-adjustment Dirichlet-drawn quantity
 described in the :ref:`exacerbation_severity_model`. This
 probability of zero very severe exacerbations out of ``total rate`` expected exacerbations is the
 marginal (Dirichlet-multinomial) probability, expressed using the Gamma function :math:`\Gamma`
@@ -360,9 +360,9 @@ marginal (Dirichlet-multinomial) probability, expressed using the Gamma function
 
 .. math::
 
-    P(\text{no very severe exacerbations}) = \dfrac{1}{\Gamma(\text{total rate} + 1)} \cdot
-        \dfrac{\Gamma(\text{total rate} + 1 - w^{\text{pre}}_{\text{very severe}})}
-            {\Gamma(1 - w^{\text{pre}}_{\text{very severe}})}
+    P(\text{no very severe exacerbations}) = \dfrac{1}{\Gamma(\text{total rate}^{(i)} + 1)} \cdot
+        \dfrac{\Gamma(\text{total rate}^{(i)} + 1 - w^{\text{pre},(i)}_{\text{very severe}})}
+            {\Gamma(1 - w^{\text{pre},(i)}_{\text{very severe}})}
 
 Finally, we toss a coin — a Bernoulli draw — to decide whether the agent had at least one very
 severe exacerbation over this span:
@@ -423,7 +423,7 @@ of Agent Initialization above:
 
 .. math::
 
-    \text{total hosp} = \text{total hosp} + n_{\text{very severe}}
+    \text{total hosp}^{(i)} = \text{total hosp}^{(i)} + n_{\text{very severe}}^{(i)}
 
 
 Iterating Over Lifetime
@@ -529,7 +529,7 @@ of Agent Initialization above:
 
 .. math::
 
-    \text{total hosp} = \text{total hosp} + n_{\text{very severe}}
+    \text{total hosp}^{(i)} = \text{total hosp}^{(i)} + n_{\text{very severe}}^{(i)}
 
 Continue to Step 8.
 

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -282,6 +282,11 @@ To initialize an agent, we set the following initial attributes:
 
        * number of exacerbations previous timepoint: 0
        * number of exacerbations current timepoint: 0
+   * - total hospitalizations
+     - The agent's cumulative count of very severe (hospitalized) exacerbations. For an agent with
+       asthma, this is initialized via the mini-simulation described in
+       :ref:`step-4-check-hospitalizations` below; otherwise it starts at 0. It is incremented
+       each subsequent time interval — see Step 8.
 
 
 Step 1: Check if the agent is over 3 years old
@@ -326,50 +331,46 @@ Step 4: Check hospitalizations
 --------------------------------
 
 Next, we determine whether the agent has previously had a very severe (i.e. hospitalized)
-exacerbation at some point since their asthma diagnosis (Step 3). This flag feeds into the
-:ref:`exacerbation_severity_model`, which increases the probability of a very severe exacerbation
+exacerbation at some point since their asthma diagnosis (Step 3). This is used in the :ref:`exacerbation_severity_model` to increase the probability of a very severe exacerbation
 for agents with a prior hospitalization.
 
 Since this agent's asthma history was not directly simulated cycle-by-cycle (it was assigned all
-at once in Steps 2 and 3), we cannot just look up whether a hospitalization occurred. In
-principle we could reconstruct the exact sequence of asthma/no-asthma cycles since diagnosis —
-but because asthma is reversible (an agent can lose and regain their asthma label via
-reassessment), the number of possible state sequences explodes combinatorially, making an exact
-calculation computationally infeasible.
-
-To simplify, we assume the agent's asthma was **not reversible** between their diagnosis age and
+at once in Steps 2 and 3), we cannot just look up whether a hospitalization occurred. Instead, we assume the agent's asthma was **not reversible** between their diagnosis age and
 two years before their current age: that is, we treat the agent as having had asthma
 continuously over that span. Under this assumption, we run a mini-simulation that sums the
 expected exacerbation rate :math:`\lambda` (using the Step 6 formula below, with that year's age,
-sex, timepoint, and control levels) over every year from the asthma diagnosis age up to two years
+sex, and control levels) over every year from the asthma diagnosis age up to two years
 before the agent's current age:
 
 .. math::
 
-    \text{total\_rate} = \sum_{y} \lambda_y
+    \text{total rate} = \sum_{y} \lambda_y
+
+where :math:`y` ranges over each year (not the simulation's own timepoint, but a calendar
+year) from the asthma diagnosis age up to two years before the agent's current age, and
+:math:`\lambda_y` is :math:`\lambda` evaluated at that year (Step 6 below).
 
 We then compute the probability that *none* of the agent's exacerbations over this span were very
-severe. Since each agent's probability of a very severe exacerbation, :math:`\pi`, is itself drawn
-from a Dirichlet distribution (see :ref:`exacerbation_severity_model`), this probability is the
-marginal (Dirichlet-multinomial) probability of zero very severe exacerbations out of
-``total_rate`` expected exacerbations:
+severe. Each agent's probability of a very severe exacerbation is
+:math:`w^{\text{pre}}_{\text{very severe}}` — the same pre-adjustment Dirichlet-drawn quantity
+described in the :ref:`exacerbation_severity_model` section of the Exacerbations Model page. This
+probability of zero very severe exacerbations out of ``total rate`` expected exacerbations is the
+marginal (Dirichlet-multinomial) probability, expressed using the Gamma function :math:`\Gamma`
+(the continuous extension of the factorial, :math:`\Gamma(n+1) = n!`):
 
 .. math::
 
-    P(\text{no very severe exacerbations}) = \dfrac{1}{\Gamma(\text{total\_rate} + 1)} \cdot
-        \dfrac{\Gamma(\text{total\_rate} + 1 - \pi)}{\Gamma(1 - \pi)}
+    P(\text{no very severe exacerbations}) = \dfrac{1}{\Gamma(\text{total rate} + 1)} \cdot
+        \dfrac{\Gamma(\text{total rate} + 1 - w^{\text{pre}}_{\text{very severe}})}
+            {\Gamma(1 - w^{\text{pre}}_{\text{very severe}})}
 
 Finally, we toss a coin — a Bernoulli draw — to decide whether the agent had at least one very
 severe exacerbation over this span:
 
 .. math::
 
-    \text{prev\_hosp} \sim \text{Bernoulli}\left(1 - P(\text{no very severe exacerbations})\right)
+    \text{prev hosp} \sim \text{Bernoulli}\left(1 - P(\text{no very severe exacerbations})\right)
 
-This non-reversibility assumption means we overestimate the number of years the agent was
-labelled as having asthma prior to the current timepoint, and therefore overestimate their
-chances of a prior hospitalization. However, since asthma reassessment (loss of the asthma label)
-is relatively rare in our data, we expect this bias to be small.
 
 Step 5: Determine asthma control levels
 -----------------------------------------
@@ -396,27 +397,10 @@ probability of the agent having fully-controlled, partially-controlled, or uncon
 Step 6: Compute the number of asthma exacerbations in the current timepoint
 ----------------------------------------------------------------------------
 
-To compute the number of asthma exacerbations in the current timepoint, we use the
-exacerbation model, which takes into account the agent's asthma control level, age, and sex,
-as well as the current timepoint. The probability of having :math:`n` exacerbations is given by a
-Poisson distribution:
-
-.. math::
-
-    P(n = k) = \dfrac{\lambda^{k}e^{-\lambda}}{k!}
-
-We determine the expected number of exacerbations, :math:`\lambda`, using the following formula:
-
-.. math::
-
-    \lambda &= e^{\mu} \\
-    \mu &= \beta_0 +
-        \beta_{\text{age}} \cdot \text{age} +
-        \beta_{\text{sex}} \cdot \text{sex} \\
-        &+\beta_{uc} \cdot P(\text{uncontrolled}) +
-        \beta_{pc} \cdot P(\text{partially controlled}) +
-        \beta_{c} \cdot P(\text{fully controlled}) \\
-        &+\log(\alpha(\text{timepoint}, \text{sex}, \text{age}))
+To compute the number of asthma exacerbations in the current timepoint, we use the exacerbation
+model, which draws a count from a Poisson distribution parameterized by the agent's control
+levels, patient-specific random effect, and the calibration multiplier :math:`\alpha` for their
+age, sex, province, and timepoint. See :ref:`exacerbation-model` for the full derivation.
 
 If the number of exacerbations is ``0``, skip to the end. Otherwise, go to Step 7.
 
@@ -424,50 +408,22 @@ If the number of exacerbations is ``0``, skip to the end. Otherwise, go to Step 
 Step 7: Compute the severity of the asthma exacerbations in the current timepoint
 ----------------------------------------------------------------------------------
 
-There are four levels of severity for asthma exacerbations:
-
-.. math::
-
-    k &= 1: \text{mild} \\
-    k &= 2: \text{moderate} \\
-    k &= 3: \text{severe} \\
-    k &= 4: \text{very severe / hospitalization}
-
-We assign the initial probability of each severity level using a Dirichlet distribution.
-
-If the agent has been previously hospitalized due to asthma:
-
-.. math::
-
-    P(k = 4 \mid t) &= \begin{cases}
-        P(k = 4 \mid t_0) \cdot \beta_{\text{prevhospped}} & \text{if age} < 14 \\
-        P(k = 4 \mid t_0) \cdot \beta_{\text{prevhospadult}} & \text{if age} \geq 14
-    \end{cases} \\
-    P(k = 1 \mid t) &= P(k = 1 \mid t_0) \cdot (1 - P(k = 4 \mid t)) \\
-    P(k = 2 \mid t) &= P(k = 2 \mid t_0) \cdot (1 - P(k = 4 \mid t)) \\
-    P(k = 3 \mid t) &= P(k = 3 \mid t_0) \cdot (1 - P(k = 4 \mid t))
-
-
-Otherwise, we use the initial probabilities of each severity level. Then, to determine the
-number of exacerbations of each severity level, we use a multinomial distribution:
-
-.. math::
-
-    p(x_1, x_2, x_3, x_4; n, p) = 
-        \dfrac{n!}{x_1! x_2! x_3! x_4!} \prod_{i=1}^4 P(k = i)^{x_i}, \quad \text{where} \quad \sum_{i=1}^4 x_i = n
+Each of the :math:`n` exacerbations from Step 6 is assigned a severity level (mild, moderate,
+severe, or very severe) via the Dirichlet-Multinomial model described in
+:ref:`exacerbation_severity_model`, including the adjustment applied if the agent has a history
+of very severe exacerbations (hospitalization).
 
 
 Step 8: Update the number of hospitalizations
 -----------------------------------------------------------------------------
 
-We add the total previous hospitalizations to the current timepoint's number of exacerbations at
-severity level 4:
+We add the current timepoint's number of very severe exacerbations to ``total_hosp``, the
+agent's cumulative hospitalization count first set during :ref:`step-4-check-hospitalizations`
+of Agent Initialization above:
 
 .. math::
 
-    \text{hospitalizations} = \text{previous hospitalizations} + x_4
-
-where :math:`x_4` is the number of exacerbations at severity level 4.
+    \text{total hosp} = \text{total hosp} + n_{\text{very severe}}
 
 
 Iterating Over Lifetime
@@ -548,26 +504,9 @@ Step 4: Compute the number of asthma exacerbations in the current timepoint
 ----------------------------------------------------------------------------
 
 To compute the number of asthma exacerbations in the current timepoint, we use the
-:ref:`exacerbation-model`, which takes into account the agent's asthma control level, age, and sex,
-as well as the current timepoint. The probability of having :math:`n` exacerbations is given by a
-Poisson distribution:
-
-.. math::
-
-    P(n = k) = \dfrac{\lambda^{k}e^{-\lambda}}{k!}
-
-We determine the expected number of exacerbations, :math:`\lambda`, using the following formula:
-
-.. math::
-
-    \lambda &= e^{\mu} \\
-    \mu &= \beta_0 +
-        \beta_{\text{age}} \cdot \text{age} +
-        \beta_{\text{sex}} \cdot \text{sex} \\
-        &+\beta_{uc} \cdot P(\text{uncontrolled}) +
-        \beta_{pc} \cdot P(\text{partially controlled}) +
-        \beta_{c} \cdot P(\text{fully controlled}) \\
-        &+\log(\alpha(\text{timepoint}, \text{sex}, \text{age}))
+:ref:`exacerbation-model`, which draws a count from a Poisson distribution parameterized by the
+agent's control levels, patient-specific random effect, and the calibration multiplier
+:math:`\alpha` for their age, sex, province, and timepoint.
 
 If the number of exacerbations is ``0``, skip to Step 8. Otherwise, go to Step 5.
 
@@ -575,48 +514,23 @@ If the number of exacerbations is ``0``, skip to Step 8. Otherwise, go to Step 5
 Step 5: Compute the severity of the asthma exacerbations in the current timepoint
 ----------------------------------------------------------------------------------
 
-There are four levels of severity for asthma exacerbations:
-
-.. math::
-
-    k &= 1: \text{mild} \\
-    k &= 2: \text{moderate} \\
-    k &= 3: \text{severe} \\
-    k &= 4: \text{very severe / hospitalization}
-
-If the agent has been previously hospitalized due to asthma:
-
-.. math::
-
-    P(k = 4 \mid t) &= \begin{cases}
-        P(k = 4 \mid t - 1) \cdot \beta_{\text{prevhospped}} & \text{if age} < 14 \\
-        P(k = 4 \mid t - 1) \cdot \beta_{\text{prevhospadult}} & \text{if age} \geq 14
-    \end{cases} \\
-    P(k = 1 \mid t) &= P(k = 1 \mid t - 1) \cdot (1 - P(k = 4 \mid t)) \\
-    P(k = 2 \mid t) &= P(k = 2 \mid t - 1) \cdot (1 - P(k = 4 \mid t)) \\
-    P(k = 3 \mid t) &= P(k = 3 \mid t - 1) \cdot (1 - P(k = 4 \mid t))
-
-
-Otherwise, we use the initial probabilities of each severity level. Then, to determine the
-number of exacerbations of each severity level, we use a multinomial distribution:
-
-.. math::
-
-    p(x_1, x_2, x_3, x_4; n, p) = 
-        \dfrac{n!}{x_1! x_2! x_3! x_4!} \prod_{i=1}^4 P(k = i)^{x_i}, \quad \text{where} \quad \sum_{i=1}^4 x_i = n
+Each of the :math:`n` exacerbations from Step 4 is assigned a severity level (mild, moderate,
+severe, or very severe) via the Dirichlet-Multinomial model described in
+:ref:`exacerbation_severity_model`, including the adjustment applied if the agent has a history
+of very severe exacerbations (hospitalization).
 
 
 Step 6: Update the number of hospitalizations
 -----------------------------------------------------------------------------
 
-We add the total previous hospitalizations to the current timepoint's number of exacerbations at
-severity level 4:
+We add the current timepoint's number of very severe exacerbations to ``total_hosp``, the
+agent's cumulative hospitalization count first set during :ref:`step-4-check-hospitalizations`
+of Agent Initialization above:
 
 .. math::
 
-    \text{hospitalizations} = \text{previous hospitalizations} + x_4
+    \text{total hosp} = \text{total hosp} + n_{\text{very severe}}
 
-where :math:`x_4` is the number of exacerbations at severity level 4.
 Continue to Step 8.
 
 Step 7: Reassess asthma diagnosis

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -353,7 +353,7 @@ year) from the asthma diagnosis age up to two years before the agent's current a
 We then compute the probability that *none* of the agent's exacerbations over this span were very
 severe. Each agent's probability of a very severe exacerbation is
 :math:`w^{\text{pre}}_{\text{very severe}}` — the same pre-adjustment Dirichlet-drawn quantity
-described in the :ref:`exacerbation_severity_model` section of the Exacerbations Model page. This
+described in the :ref:`exacerbation_severity_model`. This
 probability of zero very severe exacerbations out of ``total rate`` expected exacerbations is the
 marginal (Dirichlet-multinomial) probability, expressed using the Gamma function :math:`\Gamma`
 (the continuous extension of the factorial, :math:`\Gamma(n+1) = n!`):

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -320,10 +320,56 @@ If the agent is 3 years old, the age of asthma diagnosis is 3.
 If the agent is older than 3, we use the asthma incidence model to determine the age of asthma
 diagnosis.
 
+.. _step-4-check-hospitalizations:
+
 Step 4: Check hospitalizations
 --------------------------------
 
-Next, we check how many times agent has been hospitalized due to asthma in their lifetime.
+Next, we determine whether the agent has previously had a very severe (i.e. hospitalized)
+exacerbation at some point since their asthma diagnosis (Step 3). This flag feeds into the
+:ref:`exacerbation_severity_model`, which increases the probability of a very severe exacerbation
+for agents with a prior hospitalization.
+
+Since this agent's asthma history was not directly simulated cycle-by-cycle (it was assigned all
+at once in Steps 2 and 3), we cannot just look up whether a hospitalization occurred. In
+principle we could reconstruct the exact sequence of asthma/no-asthma cycles since diagnosis —
+but because asthma is reversible (an agent can lose and regain their asthma label via
+reassessment), the number of possible state sequences explodes combinatorially, making an exact
+calculation computationally infeasible.
+
+To simplify, we assume the agent's asthma was **not reversible** between their diagnosis age and
+two years before their current age: that is, we treat the agent as having had asthma
+continuously over that span. Under this assumption, we run a mini-simulation that sums the
+expected exacerbation rate :math:`\lambda` (using the Step 6 formula below, with that year's age,
+sex, timepoint, and control levels) over every year from the asthma diagnosis age up to two years
+before the agent's current age:
+
+.. math::
+
+    \text{total\_rate} = \sum_{y} \lambda_y
+
+We then compute the probability that *none* of the agent's exacerbations over this span were very
+severe. Since each agent's probability of a very severe exacerbation, :math:`\pi`, is itself drawn
+from a Dirichlet distribution (see :ref:`exacerbation_severity_model`), this probability is the
+marginal (Dirichlet-multinomial) probability of zero very severe exacerbations out of
+``total_rate`` expected exacerbations:
+
+.. math::
+
+    P(\text{no very severe exacerbations}) = \dfrac{1}{\Gamma(\text{total\_rate} + 1)} \cdot
+        \dfrac{\Gamma(\text{total\_rate} + 1 - \pi)}{\Gamma(1 - \pi)}
+
+Finally, we toss a coin — a Bernoulli draw — to decide whether the agent had at least one very
+severe exacerbation over this span:
+
+.. math::
+
+    \text{prev\_hosp} \sim \text{Bernoulli}\left(1 - P(\text{no very severe exacerbations})\right)
+
+This non-reversibility assumption means we overestimate the number of years the agent was
+labelled as having asthma prior to the current timepoint, and therefore overestimate their
+chances of a prior hospitalization. However, since asthma reassessment (loss of the asthma label)
+is relatively rare in our data, we expect this bias to be small.
 
 Step 5: Determine asthma control levels
 -----------------------------------------

--- a/leap/data_generation/exacerbation_data.py
+++ b/leap/data_generation/exacerbation_data.py
@@ -48,7 +48,7 @@ EXACERBATION_RATE = 0.347
 # rate(exacerbation | partially controlled) = 2 * rate(exacerbation | fully controlled)
 # rate(exacerbation | uncontrolled) = 3 * rate(exacerbation | fully controlled)
 # Source: GOAL Study (Bateman et al., 2004)
-# https://www.atsjournals.org/doi/full/10.1164/rccm.200401-033OC
+# https://doi.org/10.1164/rccm.200401-033OC
 EXACERBATION_RATE_RATIO = {
     "well_controlled": 1.0,
     "partially_controlled": 2.0,
@@ -106,7 +106,7 @@ def exacerbation_prediction(
 
     Here the :math:`\beta_i` values were calculated from the
     `Economic Burden of Asthma (EBA) study <https://bmjopen.bmj.com/content/3/9/e003360.long>`_
-    and the `GOAL Study <https://www.atsjournals.org/doi/full/10.1164/rccm.200401-033OC>`_.
+    and the `GOAL Study <https://doi.org/10.1164/rccm.200401-033OC>`_.
 
     Args:
         sex: One of "M" or "F".


### PR DESCRIPTION
## Description

This PR updates the exacerbation documentation on the exacerbation model page and its use in the simulation:

- Fixed broken dataset links and descriptions in model-exacerbation.rst (population, occurrence, and hospitalization data), including documenting the per-province structure of the CIHI hospitalization data and noting that calibration currently only covers BC and CA.
- Added missing definitions throughout the exacerbation Poisson model and Calibration section (k, beta_0 as a patient-specific random effect matching model-control.rst's convention, corrected which of beta_i/c_i comes from the Control Model vs. EBA/GOAL, clarified that lambda_C does not vary by timepoint).
- Added an expanded Severity section to model-exacerbation.rst documenting the Dirichlet-Multinomial severity model and the previous-hospitalization adjustment, including tracing the rate-multiplier constants (1.79 pediatric, 2.88 adult) to their source study (Lee et al. 2022) and adding that citation.
- Added a conceptual explanation (in a collapsible box) of why calibrating alpha from hospitalizations alone is valid for scaling the full exacerbation rate.
- Added a mermaid diagram summarizing how the calibration multiplier, control-level rate constants, and control-level probabilities combine into the exacerbation rate, and how that flows into severity assignment.
- Updated the bibliography: updated the LEAP citation to the now-published PLOS One version, added GINA and the Lee et al. 2022 natural-history study.
- Standardized notation between model-exacerbation.rst and model-simulation.rst for the severity model and the previous-hospitalization adjustment, and added the underlying methodology for how an agent's prior-hospitalization status is initialized when their asthma history wasn't directly simulated cycle-by-cycle.
- Removed duplicated/stale re-derivations of the exacerbation and severity formulas from model-simulation.rst's agent-initialization and lifetime-iteration steps in favor of cross-references to model-exacerbation.rst.
- Added a previously-missing `total_hosp` attribute to the Agent Initialization table.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

This is a documentation-only change (plus two trivial link/argument fixes in leap/data_generation/exacerbation_data.py and antibiotic_data.py). Verified by rebuilding the Sphinx docs locally after each change:

- [x] Ran `sphinx-build -b html . _build/html` from the docs/ directory after each edit and confirmed no new warnings/errors were introduced
- [x] Spot-checked rendered HTML output for new math blocks, mermaid diagram, and cross-references (labels resolve, citations resolve, collapsible box renders)

## Linked PRs / Issues

- resplab/leap#74 (bug filed for a schema mismatch discovered while writing this documentation: exacerbation_calibration.csv's actual schema does not match what the current generation script would produce)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

