### PR TITLE
Update cost documentation

### DIFF
--- a/docs/model/model-cost.rst
+++ b/docs/model/model-cost.rst
@@ -57,7 +57,7 @@ The data used for background cost by asthma control level also comes from the sa
 `Table I <https://www.sciencedirect.com/science/article/pii/S0091674919316343#tbl1>`_:
 
 .. list-table::
-   :widths: 25 75
+   :widths: 75 25
    :header-rows: 1
 
    * - Variable
@@ -105,7 +105,7 @@ The conversion rate is applied to obtain the 2023 CAD
 costs used in the model:
 
 .. list-table:: Direct costs (2023 CAD)
-   :widths: 25 75
+   :widths: 70 30
    :header-rows: 1
 
    * - Variable

--- a/docs/model/model-cost.rst
+++ b/docs/model/model-cost.rst
@@ -1,7 +1,7 @@
 .. _cost-model:
 
 =====================
-Asthma Cost Model
+Cost Model
 =====================
 
 Data
@@ -13,7 +13,7 @@ Cost Due to Asthma Exacerbations
 **************************************
 
 The data used in the cost model comes from the study :cite:`yaghoubi`, in
-`Table I <https://www.sciencedirect.com/science/article/pii/S0091674919316343#tbl1>`_:
+`Table I <https://www.sciencedirect.com/science/article/pii/S0091674919316343#tbl1>`_.
 
 .. list-table::
    :widths: 25 75
@@ -21,18 +21,23 @@ The data used in the cost model comes from the study :cite:`yaghoubi`, in
 
    * - Variable
      - Value
-   * - Direct costs of exacerbation by severity: mild
+   * - Direct costs of mild exacerbation
      - $130 USD
-   * - Direct costs of exacerbation by severity: moderate
+   * - Direct costs of moderate exacerbation
      - $594 USD
-   * - Direct costs of exacerbation by severity: (very) severe
+   * - Direct costs of severe exacerbation
+     - $2425 USD (see :ref:`note <cost-severe-exacerbation-note>` below)
+   * - Direct costs of very severe exacerbation
      - $9900 USD
+
+.. _cost-severe-exacerbation-note:
 
 .. note::
 
-    In the paper, ``severe`` exacerbations are equivalent to our definition of ``very severe``
+    In :cite:`yaghoubi`, ``severe`` exacerbations are equivalent to our definition of ``very severe``
     exacerbations. Thus, we are missing the cost of ``severe`` exacerbations. To account for this,
-    we defined the cost of a ``severe`` exacerbation as:
+    we defined the cost of a ``severe`` exacerbation as the geometric mean of the costs of
+    ``moderate`` and ``very severe`` exacerbations, i.e. the average of the two costs on the log-scale:
 
     .. math::
 
@@ -48,7 +53,7 @@ The data used in the cost model comes from the study :cite:`yaghoubi`, in
 Cost Due to Asthma Control Levels
 **********************************
 
-The data used for the cost by asthma control level also comes from the study :cite:`yaghoubi`, in
+The data used for background cost by asthma control level also comes from the same study :cite:`yaghoubi`, in
 `Table I <https://www.sciencedirect.com/science/article/pii/S0091674919316343#tbl1>`_:
 
 .. list-table::
@@ -65,18 +70,79 @@ The data used for the cost by asthma control level also comes from the study :ci
      - $3127 USD
 
 
-Model
-======
+.. _cost-data-currency-conversion:
+
+Currency Conversion
+**************************************
+
+The costs reported in :cite:`yaghoubi` above, for both exacerbations and asthma control levels,
+are in USD, reported in September 2018 price year. To match the target price year of our model, all costs
+are converted to 2023 CAD in two steps:
+
+#. **Inflation adjustment**: 2018 USD are converted to 2023 USD using the Consumer Price
+   Index (CPI) Inflation Calculator from the `U.S. Bureau of Labor Statistics
+   <https://www.bls.gov/data/inflation_calculator.htm>`_:
+
+   .. math::
+
+       1 \text{ USD (Sept 2018)} = 1.22 \text{ USD (Sept 2023)}
+
+#. **Exchange rate conversion**: 2023 USD are converted to 2023 CAD using the
+   `Bank of Canada's annual average exchange rate
+   <https://www.bankofcanada.ca/rates/exchange/annual-average-exchange-rates/>`_:
+
+   .. math::
+
+       1 \text{ USD (2023)} = 1.36 \text{ CAD (2023)}
+
+Combining these two factors gives the overall USD-to-CAD conversion rate used in the model:
 
 .. math::
 
-  \text{cost} = \sum_{S=1}^4 n_E(S) \cdot \text{cost}_E(S) + 
-    \sum_{L=1}^3 P(L) \cdot \text{cost}_C(L)
+    \text{exchange_rate_usd_cad} = 1.22 \times 1.36 \approx 1.66
+
+The conversion rate is applied to obtain the 2023 CAD
+costs used in the model:
+
+.. list-table:: Direct costs (2023 CAD)
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Variable
+     - Value
+   * - Mild exacerbation
+     - $216 CAD
+   * - Moderate exacerbation
+     - $986 CAD
+   * - Severe exacerbation
+     - $4026 CAD
+   * - Very severe exacerbation
+     - $16434 CAD
+   * - Well-controlled asthma (annual)
+     - $3938 CAD
+   * - Not-well-controlled asthma (annual)
+     - $4922 CAD
+   * - Uncontrolled asthma (annual)
+     - $5191 CAD
+
+
+Model
+======
+
+Exacerbation costs are applied per exacerbation event, i.e. an agent incurs this cost
+each time they have an exacerbation of the corresponding severity. Control level costs are weighted by :math:`P(y^{(i)} = k)`, which per the :ref:`control-model` represents
+the proportion of the time interval agent :math:`i` spends at control level :math:`k`:
+
+.. math::
+
+  \text{cost} = \sum_{S=1}^4 n_{\text{Exac}}^{(i)}(S) \cdot \text{cost}_E(S) +
+    \sum_{k=1}^3 P(y^{(i)} = k) \cdot \text{cost}_C(k)
 
 
 where:
 
-* :math:`n_E(S)` is the number of exacerbations at severity level :math:`S`
+* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of exacerbations at severity level :math:`S`
 * :math:`\text{cost}_E(S)` is the cost of an exacerbation at severity level :math:`S`
-* :math:`P(L)` is the probability of being at asthma control level :math:`L`
-* :math:`\text{cost}_C(L)` is the cost of being at asthma control level :math:`L`
+* :math:`P(y^{(i)} = k)` is the probability of agent :math:`i` being at asthma control level
+  :math:`k`
+* :math:`\text{cost}_C(k)` is the cost of being at asthma control level :math:`k`

--- a/docs/model/model-cost.rst
+++ b/docs/model/model-cost.rst
@@ -16,7 +16,7 @@ The data used in the cost model comes from the study :cite:`yaghoubi`, in
 `Table I <https://www.sciencedirect.com/science/article/pii/S0091674919316343#tbl1>`_.
 
 .. list-table::
-   :widths: 25 75
+   :widths: 70 30
    :header-rows: 1
 
    * - Variable

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -595,7 +595,7 @@ using the :ref:`utility-model`:
 .. math::
 
     u := u_{\text{baseline}} - A \cdot \left(
-      \sum_{S=1}^{4} d_E(S) \cdot n_E(S) + \sum_{L=1}^{3} d_C(L) \cdot C(L)
+      \sum_{S=1}^{4} d_E(S) \cdot n_{\text{Exac}}^{(i)}(S) + \sum_{L=1}^{3} d_C(L) \cdot C(L)
     \right)
 
 where:
@@ -603,7 +603,7 @@ where:
 * :math:`u_{\text{baseline}}` is the baseline utility for a person of a given age and sex
   (without asthma)
 * :math:`d_{E}(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
-* :math:`n_E(S)` is the number of asthma exacerbations of severity level :math:`S` in a time interval
+* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of asthma exacerbations of severity level :math:`S` in a time interval
 * :math:`S \in \{1, 2, 3, 4\}` is the asthma exacerbation severity level (1 = mild, 2 =
   moderate, 3 = severe, 4 = very severe)
 * :math:`d_{C}` is the disutility due to having asthma at control level :math:`L`
@@ -616,21 +616,22 @@ where:
 Step 9: Compute cost
 ---------------------------
 
-Next, we compute the cost due to asthma for the agent in Canadian dollars using the
+Next, we compute the cost for the agent using the
 :ref:`cost-model`:
 
 .. math::
 
-  \text{cost} = \sum_{S=1}^4 n_E(S) \cdot \text{cost}_E(S) + 
-    \sum_{L=1}^3 P(L) \cdot \text{cost}_C(L)
+  \text{cost} = \sum_{S=1}^4 n_{\text{Exac}}^{(i)}(S) \cdot \text{cost}_E(S) +
+    \sum_{k=1}^3 P(y^{(i)} = k) \cdot \text{cost}_C(k)
 
 
 where:
 
-* :math:`n_E(S)` is the number of exacerbations at severity level :math:`S`
+* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of exacerbations at severity level :math:`S`
 * :math:`\text{cost}_E(S)` is the cost of an exacerbation at severity level :math:`S`
-* :math:`P(L)` is the probability of being at asthma control level :math:`L`
-* :math:`\text{cost}_C(L)` is the cost of being at asthma control level :math:`L`
+* :math:`P(y^{(i)} = k)` is the probability of agent :math:`i` being at asthma control level
+  :math:`k`
+* :math:`\text{cost}_C(k)` is the cost of being at asthma control level :math:`k`
 
 Step 10: Check if agent dies
 -------------------------------

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -595,7 +595,7 @@ using the :ref:`utility-model`:
 .. math::
 
     u := u_{\text{baseline}} - A \cdot \left(
-      \sum_{S=1}^{4} d_E(S) \cdot n_{\text{Exac}}^{(i)}(S) + \sum_{L=1}^{3} d_C(L) \cdot C(L)
+      \sum_{S=1}^{4} d_E(S) \cdot n_E(S) + \sum_{L=1}^{3} d_C(L) \cdot C(L)
     \right)
 
 where:
@@ -603,7 +603,7 @@ where:
 * :math:`u_{\text{baseline}}` is the baseline utility for a person of a given age and sex
   (without asthma)
 * :math:`d_{E}(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
-* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of asthma exacerbations of severity level :math:`S` in a time interval
+* :math:`n_E(S)` is the number of asthma exacerbations of severity level :math:`S` in a time interval
 * :math:`S \in \{1, 2, 3, 4\}` is the asthma exacerbation severity level (1 = mild, 2 =
   moderate, 3 = severe, 4 = very severe)
 * :math:`d_{C}` is the disutility due to having asthma at control level :math:`L`


### PR DESCRIPTION
## Description

This PR updates the asthma cost model documentation (`docs/model/model-cost.rst`) to add missing detail:

- Documents how costs from Yaghoubi et al. are converted from 2018 USD to 2023 CAD, including the CPI inflation adjustment (1.22x, from the BLS Inflation Calculator) and the USD-to-CAD exchange rate (1.36x, from the Bank of Canada), combining to the `exchange_rate_usd_cad = 1.66` constant already used in `leap/cost.py`.
- Adds a "Direct costs (2023 CAD)" table showing all exacerbation-severity and control-level costs after conversion.
- Adds a `severe` exacerbation cost row to the raw cost table, linked to the existing geometric-mean derivation note, and expands that note to explain the calculation in words.
- Clarifies that exacerbation costs are applied per event, while control-level costs are weighted by the probability of being at each control level.
- Aligns the cost model's mathematical notation, `P(y^{(i)} = k)` and `n_Exac^{(i)}(S)`, with the conventions used in `model-control.rst` (ordinal regression notation) and the exacerbation model, and propagates the same notation fix to the duplicate formula in `model-simulation.rst` (Step 9: Compute cost). 
- Renames the page title from "Asthma Cost Model" to "Cost Model" for consistency with "Utility Model".

No code or behavior changes — documentation only.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

This is a documentation-only change with no code impact, so no unit tests were added or modified. To verify:

- [x] Built the docs locally with `sphinx-build docs _build -E -a` and confirmed `model-cost.rst` and `model-simulation.rst` render without new errors
- [x] Verified the `exchange_rate_usd_cad = 1.66` constant documented here matches the value used in `leap/cost.py` and `leap/processed_data/time_delta_365/config.json`
- [x] Cross-checked the cited USD cost figures against `tests/test_cost.py` and `docs/cli/config.rst`

## Linked PRs / Issues

None.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

