### PR TITLE
Update utility documentation

### DIFF
--- a/docs/_static/bibliography.bib
+++ b/docs/_static/bibliography.bib
@@ -144,6 +144,59 @@ author = {Mohsen Yaghoubi and Amin Adibi and Zafar Zafari and J. Mark FitzGerald
 keywords = {Asthma, cost-effectiveness analysis, diagnosis, medical test}
 }
 
+@article{lloyd2007,
+    author = {Lloyd, A. and Price, D. and Brown, R.},
+    title = {The impact of asthma exacerbations on health-related quality of life in moderate to
+        severe asthma patients in the UK},
+    journal = {Primary Care Respiratory Journal},
+    volume = {16},
+    number = {1},
+    pages = {22-27},
+    year = {2007},
+    doi = {10.3132/pcrj.2007.00002},
+    url = {https://doi.org/10.3132/pcrj.2007.00002}
+}
+
+@article{campbell2010,
+    author = {Campbell, J. D. and Spackman, D. E. and Sullivan, S. D.},
+    title = {The costs and consequences of omalizumab in uncontrolled asthma from a USA payer
+        perspective},
+    journal = {Allergy},
+    volume = {65},
+    number = {9},
+    pages = {1141-1148},
+    year = {2010},
+    doi = {10.1111/j.1398-9995.2010.02336.x},
+    url = {https://doi.org/10.1111/j.1398-9995.2010.02336.x}
+}
+
+@article{aldington2007,
+    author = {Aldington, S. and Beasley, R.},
+    title = {Asthma exacerbations. 5: assessment and management of severe asthma in adults in
+        hospital},
+    journal = {Thorax},
+    volume = {62},
+    number = {5},
+    pages = {447-458},
+    year = {2007},
+    doi = {10.1136/thx.2005.045203},
+    url = {https://doi.org/10.1136/thx.2005.045203}
+}
+
+@article{mctaggartcowan2008,
+    author = {McTaggart-Cowan, H. M. and Shi, P. and Fitzgerald, J. M. and Anis, A. H. and
+        Kopec, J. A. and Bai, T. R. and others},
+    title = {An evaluation of patients' willingness to trade symptom-free days for
+        asthma-related treatment risks: a discrete choice experiment},
+    journal = {Journal of Asthma},
+    volume = {45},
+    number = {8},
+    pages = {630-638},
+    year = {2008},
+    doi = {10.1080/02770900802126990},
+    url = {https://doi.org/10.1080/02770900802126990}
+}
+
 @article{einarson,
     title={
         Utilities for asthma and COPD according to category of severity: a comprehensive

--- a/docs/model/model-cost.rst
+++ b/docs/model/model-cost.rst
@@ -135,13 +135,13 @@ the proportion of the time interval agent :math:`i` spends at control level :mat
 
 .. math::
 
-  \text{cost} = \sum_{S=1}^4 n_{\text{Exac}}^{(i)}(S) \cdot \text{cost}_E(S) +
+  \text{cost}^{(i)} = \sum_{S=1}^4 n_E^{(i)}(S) \cdot \text{cost}_E(S) +
     \sum_{k=1}^3 P(y^{(i)} = k) \cdot \text{cost}_C(k)
 
 
 where:
 
-* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of exacerbations at severity level :math:`S`
+* :math:`n_E^{(i)}(S)` is the number of exacerbations at severity level :math:`S`
 * :math:`\text{cost}_E(S)` is the cost of an exacerbation at severity level :math:`S`
 * :math:`P(y^{(i)} = k)` is the probability of agent :math:`i` being at asthma control level
   :math:`k`

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -556,23 +556,27 @@ using the :ref:`utility-model`:
 
 .. math::
 
-    u := u_{\text{baseline}} - A \cdot \left(
-      \sum_{S=1}^{4} d_E(S) \cdot n_E(S) + \sum_{L=1}^{3} d_C(L) \cdot C(L)
-    \right)
+    u =
+    \begin{cases}
+        u_{\text{age}, \text{sex}} & \text{if the person does not have asthma} \\[6pt]
+        \max\left(0,\ u_{\text{age}, \text{sex}} - \left(
+          \sum_{S=1}^{4} n_{\text{Exac}}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y = k) \cdot d_C(k)
+        \right)\right) & \text{if the person has asthma}
+    \end{cases}
 
 where:
 
-* :math:`u_{\text{baseline}}` is the baseline utility for a person of a given age and sex
-  (without asthma)
-* :math:`d_{E}(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
-* :math:`n_E(S)` is the number of asthma exacerbations of severity level :math:`S` in a time interval
-* :math:`S \in \{1, 2, 3, 4\}` is the asthma exacerbation severity level (1 = mild, 2 =
-  moderate, 3 = severe, 4 = very severe)
-* :math:`d_{C}` is the disutility due to having asthma at control level :math:`L`
-* :math:`C(L)` is the proportion of the time interval spent at asthma control level :math:`L`
-* :math:`L \in \{1, 2, 3\}` is the asthma control level (1 = well-controlled, 2 =
-  partially-controlled, 3 = uncontrolled)
-* :math:`A` is a boolean indicating whether the person has asthma
+* :math:`u_{\text{age}, \text{sex}}` is the baseline utility for a person of the given age and
+  sex (without asthma)
+* :math:`n_{\text{Exac}}(S)` is the number of exacerbations at severity level :math:`S` in a
+  time interval
+* :math:`d_E(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
+* :math:`S \in \{\text{mild}, \text{moderate}, \text{severe}, \text{very severe}\}` is the asthma
+  exacerbation severity level
+* :math:`P(y = k)` is the probability of being at asthma control level :math:`k`
+* :math:`d_C(k)` is the disutility due to being at asthma control level :math:`k`
+* :math:`k \in \{\text{well-controlled}, \text{partially-controlled}, \text{uncontrolled}\}` is
+  the asthma control level
 
 
 Step 9: Compute cost

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -550,30 +550,31 @@ they lose their diagnosis. For this we use a Bernoulli distribution:
 Step 8: Compute utility
 ---------------------------
 
-Utility is a measure of the agent's quality of life, which can be affected by asthma control,
-exacerbations, and hospitalizations. We compute the utility for the agent in the current timepoint
+We compute the health state utility for the agent in the current timepoint
 using the :ref:`utility-model`:
 
 .. math::
 
-    u =
+    \small
+    u^{(i)} =
     \begin{cases}
-        u_{\text{age}, \text{sex}} & \text{if the person does not have asthma} \\[6pt]
-        \max\left(0,\ u_{\text{age}, \text{sex}} - \left(
-          \sum_{S=1}^{4} n_{\text{Exac}}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y = k) \cdot d_C(k)
-        \right)\right) & \text{if the person has asthma}
+        u_{\text{age}, \text{sex}}^{(i)} & \text{if agent } i \text{ does not have asthma} \\[6pt]
+        \max\left(0,\ u_{\text{age}, \text{sex}}^{(i)} - \left(
+          \sum_{S=1}^{4} n_{\text{Exac}}^{(i)}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y^{(i)} = k) \cdot d_C(k)
+        \right)\right) & \text{if agent } i \text{ has asthma}
     \end{cases}
 
 where:
 
-* :math:`u_{\text{age}, \text{sex}}` is the baseline utility for a person of the given age and
-  sex (without asthma)
-* :math:`n_{\text{Exac}}(S)` is the number of exacerbations at severity level :math:`S` in a
-  time interval
+* :math:`u_{\text{age}, \text{sex}}^{(i)}` is the baseline utility for agent :math:`i`, of the
+  given age and sex (without asthma)
+* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of exacerbations at severity level :math:`S` in a
+  time interval, for agent :math:`i`
 * :math:`d_E(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
 * :math:`S \in \{\text{mild}, \text{moderate}, \text{severe}, \text{very severe}\}` is the asthma
   exacerbation severity level
-* :math:`P(y = k)` is the probability of being at asthma control level :math:`k`
+* :math:`P(y^{(i)} = k)` is the probability of agent :math:`i` being at asthma control level
+  :math:`k`
 * :math:`d_C(k)` is the disutility due to being at asthma control level :math:`k`
 * :math:`k \in \{\text{well-controlled}, \text{partially-controlled}, \text{uncontrolled}\}` is
   the asthma control level

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -550,8 +550,9 @@ they lose their diagnosis. For this we use a Bernoulli distribution:
 Step 8: Compute utility
 ---------------------------
 
-We compute the health state utility for the agent in the current timepoint
-using the :ref:`utility-model`:
+Health state utility is a measure of the agent's quality of life, which can be affected by
+asthma control and exacerbations. We compute the health state utility for the agent in the
+current timepoint using the :ref:`utility-model`:
 
 .. math::
 
@@ -560,7 +561,7 @@ using the :ref:`utility-model`:
     \begin{cases}
         u_{\text{age}, \text{sex}}^{(i)} & \text{if agent } i \text{ does not have asthma} \\[6pt]
         \max\left(0,\ u_{\text{age}, \text{sex}}^{(i)} - \left(
-          \sum_{S=1}^{4} n_{\text{Exac}}^{(i)}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y^{(i)} = k) \cdot d_C(k)
+          \sum_{S=1}^{4} n_E^{(i)}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y^{(i)} = k) \cdot d_C(k)
         \right)\right) & \text{if agent } i \text{ has asthma}
     \end{cases}
 
@@ -568,7 +569,7 @@ where:
 
 * :math:`u_{\text{age}, \text{sex}}^{(i)}` is the baseline utility for agent :math:`i`, of the
   given age and sex (without asthma)
-* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of exacerbations at severity level :math:`S` in a
+* :math:`n_E^{(i)}(S)` is the number of exacerbations at severity level :math:`S` in a
   time interval, for agent :math:`i`
 * :math:`d_E(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
 * :math:`S \in \{\text{mild}, \text{moderate}, \text{severe}, \text{very severe}\}` is the asthma
@@ -588,13 +589,13 @@ Next, we compute the cost for the agent using the
 
 .. math::
 
-  \text{cost} = \sum_{S=1}^4 n_{\text{Exac}}^{(i)}(S) \cdot \text{cost}_E(S) +
+  \text{cost}^{(i)} = \sum_{S=1}^4 n_E^{(i)}(S) \cdot \text{cost}_E(S) +
     \sum_{k=1}^3 P(y^{(i)} = k) \cdot \text{cost}_C(k)
 
 
 where:
 
-* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of exacerbations at severity level :math:`S`
+* :math:`n_E^{(i)}(S)` is the number of exacerbations at severity level :math:`S`
 * :math:`\text{cost}_E(S)` is the cost of an exacerbation at severity level :math:`S`
 * :math:`P(y^{(i)} = k)` is the probability of agent :math:`i` being at asthma control level
   :math:`k`

--- a/docs/model/model-utility.rst
+++ b/docs/model/model-utility.rst
@@ -4,10 +4,6 @@
 Utility Model
 =================
 
-In economics, the ``utility`` is a number that represents how satisfied a person is with a certain
-situation. In the context of the ``LEAP`` model, it is used to quantify the health-related quality
-of life of individuals with asthma. 
-
 Datasets
 =================
 
@@ -16,22 +12,16 @@ EQ5D
 
 The `EQ5D <https://euroqol.org/information-and-support/euroqol-instruments/eq-5d-5l/>`_ is a
 standardized instrument used to measure health-related quality of life. It consists of
-five dimensions: mobility, self-care, usual activities, pain/discomfort, and anxiety/depression.
-The EQ5D is widely used in health economics and clinical trials to assess the impact of diseases
-and treatments on quality of life.
+five dimensions: mobility, self-care, usual activities, pain/discomfort, and anxiety/depression. Each dimension has five levels of severity, ranging from no problems to extreme problems.
 
-
-We use the EQ5D values to calculate the baseline utility for an individual of a given age and sex.
-For example, suppose we have a 30-year-old female with asthma. We can use the EQ5D values to
-calculate her baseline utility (her utility if she didn't have asthma), and then we can compute
-her net utility by subtracting the utility loss due to asthma.
-
-The EQ5D data was obtained from
+EQ-5D-5L data for the general population was obtained from
 `Table 3 <https://link.springer.com/article/10.1007/s10198-023-01570-1/tables/3>`_ in the paper
 `Canada population norms for the EQ-5D-5L <https://doi.org/10.1007/s10198-023-01570-1>`_
 :cite:`eq5d2024`.
 
-After processing the EQ5D data, our dataset is formatted as follows:
+After processing the EQ5D data,
+`leap/processed_data/eq5d_canada.csv <https://github.com/resplab/leap/blob/main/leap/processed_data/eq5d_canada.csv>`_,
+is formatted as follows:
 
 .. raw:: html
 
@@ -68,7 +58,7 @@ After processing the EQ5D data, our dataset is formatted as follows:
           <code class="notranslate">float</code>
         </td>
         <td>
-          The baseline utility for a person of a given age and sex.
+          The health state utility for a person of a given age and sex.
           Range <code class="notranslate">[0, 1]</code>.
         </td>
       </tr>
@@ -79,63 +69,79 @@ After processing the EQ5D data, our dataset is formatted as follows:
         </td>
         <td>
             The standard deviation of the utility value, used to account for uncertainty in the
-            utility value. Standard deviation for <code class="notranslate">age &lt 18</code> is
-            set to 0 since those EQ5D values were interpolated.
+            utility value.
         </td>
       </tr>
     </tbody>
     </table>
+
+Since the EQ-5D-5L data described above only covers individuals aged 18 and older, the utility
+values for ages 0 to 17 are interpolated. We assume that utility increases linearly from a value
+of 1 (perfect health) at age 0 to the observed EQ-5D value at age 18, :math:`u_{18}`, separately
+for each sex:
+
+.. math::
+
+    u_{\text{age}} = 1 - \dfrac{1 - u_{18}}{18} \times \text{age}, \quad \text{age} \in [0, 17]
+
+Since these values are derived rather than directly observed, the standard deviation ``sd`` for
+ages :math:`< 18` is set to ``0``, as noted in the table above.
 
 .. _utility-data-exacerbations:
 
 Disutility Due to Asthma Exacerbations
 *****************************************
 
-As in the :ref:`control-model`, we used the study :cite:`yaghoubi`, in
-`Table I <https://www.sciencedirect.com/science/article/pii/S0091674919316343#tbl1>`_:
+The health state utility values stratified by exacerbation severity come from
+:cite:`yaghoubi`, in
+`Table I <https://www.sciencedirect.com/science/article/pii/S0091674919316343#tbl1>`_, originally
+sourced from :cite:`lloyd2007` and :cite:`campbell2010`:
 
 .. list-table::
+   :widths: 70 30
    :header-rows: 1
 
    * - Variable
      - Value
-   * - Utility of exacerbation by severity: mild
+   * - Utility of mild exacerbation
      - 0.57
-   * - Utility of exacerbation by severity: moderate
+   * - Utility of moderate exacerbation
      - 0.45
-   * - Utility of exacerbation by severity: (very) severe
+   * - Utility of severe exacerbation
+     - 0.39 (see :ref:`note <utility-severe-exacerbation-note>` below)
+   * - Utility of very severe exacerbation
      - 0.33
 
+.. _utility-severe-exacerbation-note:
 
 .. note::
 
-    In the paper, ``severe`` exacerbations are equivalent to our definition of ``very severe``
-    exacerbations. Thus, we are missing the utility of ``severe`` exacerbations. To account for this,
-    we defined the utility of a ``severe`` exacerbation as:
+    In :cite:`yaghoubi`, ``severe`` exacerbations are equivalent to our definition of ``very severe``
+    exacerbations. Thus, we are missing the utility of ``severe`` exacerbations. To account for
+    this, we defined the utility of a ``severe`` exacerbation as the arithmetic mean of the
+    utilities of ``moderate`` and ``very severe`` exacerbations:
 
     .. math::
 
-        \text{utility}(\text{severe}) &= \dfrac{
-            \text{utility}(\text{moderate}) +
-            \text{utility}(\text{very severe})
+        u_E(\text{severe}) &= \dfrac{
+            u_E(\text{moderate}) + u_E(\text{very severe})
         }{2} \\
         &= \dfrac{0.45 + 0.33}{2} = 0.39
 
-
-Now, these are utility values, but we want *disutility*. Since the study :cite:`yaghoubi` starts at
-age 15, we set that as the baseline age. According to the EQ5D data, the baseline utility for a
-15-year-old is ``0.9``. Thus, the disutility due to asthma exacerbations is given by:
+We need to convert these health state utilities to disutilities due to exacerbations. According to
+:cite:`lloyd2007`, the mean EQ-5D utility for asthma patients with no exacerbation was ``0.89``; we
+use this as the baseline. Thus, the disutility due to asthma exacerbations is given by:
 
 .. math::
 
-    d_E(S) = 0.9 - u_E(S)
+    d_E(S) = 0.89 - u_E(S)
 
 where:
 
 * :math:`d_E(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
 * :math:`u_E(S)` is the utility due to an asthma exacerbation of severity level :math:`S`
-* :math:`S \in \{1, 2, 3, 4\}` is the asthma exacerbation severity level (1 = mild, 2 =
-  moderate, 3 = severe, 4 = very severe)
+* :math:`S \in \{\text{mild}, \text{moderate}, \text{severe}, \text{very severe}\}` is the asthma
+  exacerbation severity level
 
 
 .. list-table::
@@ -146,21 +152,21 @@ where:
      - Disutility
    * - Mild
      - 0.57
-     - 0.33
+     - 0.32
    * - Moderate
      - 0.45
-     - 0.45
+     - 0.44
    * - Severe
      - 0.39
-     - 0.51
+     - 0.50
    * - Very Severe
      - 0.33
-     - 0.57
+     - 0.56
 
 Now, the values listed in this table are the disutility for having an asthma exacerbation of a given
 severity for an entire year. We assume that a mild asthma exacerbation lasts for 7 days, while
-all the other severity levels last for 14 days. To convert these values we have the weekly
-utility:
+all the other severity levels last for 14 days :cite:`aldington2007`. To convert these values we
+have the weekly disutility:
 
 .. math::
 
@@ -177,34 +183,35 @@ utility:
      - Weekly Disutility
      - Disutility per Exacerbation
    * - Mild
-     - 0.33
+     - 0.32
      - 7 days
-     - 0.00633
-     - 0.00633
+     - 0.00615
+     - 0.00615
    * - Moderate
-     - 0.45
+     - 0.44
      - 14 days
-     - 0.00865
-     - 0.01731
+     - 0.00846
+     - 0.01692
    * - Severe
-     - 0.51
+     - 0.50
      - 14 days
-     - 0.00981
-     - 0.01962
+     - 0.00962
+     - 0.01923
    * - (Very) Severe
-     - 0.57
+     - 0.56
      - 14 days
-     - 0.01096
-     - 0.02192
+     - 0.01077
+     - 0.02154
 
 
 .. _utility-data-control:
 Disutility Due to Asthma Control Levels
 **********************************************
 
-We used
-`Table 3 <https://www.tandfonline.com/doi/pdf/10.3111/13696998.2015.1025793#page=6.08>`_
-in the study :cite:`einarson` to obtain the utility values stratified by asthma control level:
+The health state utility values stratified by asthma control level come from a discrete choice
+experiment of 157 adult patients with asthma in Canada :cite:`mctaggartcowan2008`, as reported in
+`Table 3 <https://www.tandfonline.com/doi/pdf/10.3111/13696998.2015.1025793#page=6.08>`_ of
+:cite:`einarson`:
 
 .. list-table::
    :header-rows: 1
@@ -231,19 +238,21 @@ in the study :cite:`einarson` to obtain the utility values stratified by asthma 
      - 0.210
 
 As with the exacerbation severity, we want to convert these utility values to disutility values.
-We use the baseline utility for a 15-year-old of ``0.9``. Thus, the disutility stratified by
-asthma control is given by:
+We use age 15 as the baseline age, consistent with the minimum age (15 years) of the target population in :cite:`yaghoubi`. According to the
+`EQ5D data <https://github.com/resplab/leap/blob/main/leap/processed_data/eq5d_canada.csv>`_,
+the baseline utility for a 15-year-old is ``0.9``. Thus, the disutility stratified by asthma
+control is given by:
 
 .. math::
 
-    d_C(L) = 0.9 - u_C(L)
+    d_C(k) = 0.9 - u_C(k)
 
 where:
 
-* :math:`d_C(L)` is the disutility due to asthma control level :math:`L`
-* :math:`u_C(L)` is the utility due to asthma control level :math:`L`
-* :math:`L \in \{1, 2, 3\}` is the asthma control level (1 = well-controlled, 2 =
-  partially-controlled, 3 = uncontrolled)
+* :math:`d_C(k)` is the disutility due to asthma control level :math:`k`
+* :math:`u_C(k)` is the utility due to asthma control level :math:`k`
+* :math:`k \in \{\text{well-controlled}, \text{partially-controlled}, \text{uncontrolled}\}` is
+  the asthma control level
 
 
 .. list-table::
@@ -266,25 +275,32 @@ where:
 Model: Calculating Utility
 ===========================
 
-The net utility is given by the formula:
+Exacerbation disutility is applied per exacerbation event, i.e. it is incurred each time there is
+an exacerbation of the corresponding severity. Control level disutility is weighted by
+:math:`P(y = k)`, which per the :ref:`control-model` represents the proportion of the time interval
+spent at control level :math:`k`. The net utility is given by the formula:
 
 .. math::
 
-    u := u_{\text{baseline}} - A \cdot \left(
-      \sum_{S=1}^{4} d_E(S) \cdot n_E(S) + \sum_{L=1}^{3} d_C(L) \cdot C(L)
-    \right)
+    u =
+    \begin{cases}
+        u_{\text{age}, \text{sex}} & \text{if the person does not have asthma} \\[6pt]
+        \max\left(0,\ u_{\text{age}, \text{sex}} - \left(
+          \sum_{S=1}^{4} n_{\text{Exac}}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y = k) \cdot d_C(k)
+        \right)\right) & \text{if the person has asthma}
+    \end{cases}
 
 where:
 
-* :math:`u_{\text{baseline}}` is the baseline utility for a person of a given age and sex
-  (without asthma)
-* :math:`d_{E}(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
-* :math:`n_E(S)` is the number of asthma exacerbations of severity level :math:`S` in a time interval
-* :math:`S \in \{1, 2, 3, 4\}` is the asthma exacerbation severity level (1 = mild, 2 =
-  moderate, 3 = severe, 4 = very severe)
-* :math:`d_{C}` is the disutility due to having asthma at control level :math:`L`
-* :math:`C(L)` is the proportion of the time interval spent at asthma control level :math:`L`
-* :math:`L \in \{1, 2, 3\}` is the asthma control level (1 = well-controlled, 2 =
-  partially-controlled, 3 = uncontrolled)
-* :math:`A` is a boolean indicating whether the person has asthma
+* :math:`u_{\text{age}, \text{sex}}` is the baseline utility for a person of the given age and
+  sex (without asthma)
+* :math:`n_{\text{Exac}}(S)` is the number of exacerbations at severity level :math:`S` in a
+  time interval
+* :math:`d_E(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
+* :math:`S \in \{\text{mild}, \text{moderate}, \text{severe}, \text{very severe}\}` is the asthma
+  exacerbation severity level
+* :math:`P(y = k)` is the probability of being at asthma control level :math:`k`
+* :math:`d_C(k)` is the disutility due to being at asthma control level :math:`k`
+* :math:`k \in \{\text{well-controlled}, \text{partially-controlled}, \text{uncontrolled}\}` is
+  the asthma control level
 

--- a/docs/model/model-utility.rst
+++ b/docs/model/model-utility.rst
@@ -76,7 +76,7 @@ is formatted as follows:
     </table>
 
 Since the EQ-5D-5L data described above only covers individuals aged 18 and older, the utility
-values for ages 0 to 17 are interpolated. We assume that utility increases linearly from a value
+values for ages 0 to 17 are interpolated. We assume that utility decreases linearly from a value
 of 1 (perfect health) at age 0 to the observed EQ-5D value at age 18, :math:`u_{18}`, separately
 for each sex:
 
@@ -85,7 +85,7 @@ for each sex:
     u_{\text{age}} = 1 - \dfrac{1 - u_{18}}{18} \times \text{age}, \quad \text{age} \in [0, 17]
 
 Since these values are derived rather than directly observed, the standard deviation ``sd`` for
-ages :math:`< 18` is set to ``0``, as noted in the table above.
+ages :math:`< 18` is set to ``0``.
 
 .. _utility-data-exacerbations:
 
@@ -117,9 +117,7 @@ sourced from :cite:`lloyd2007` and :cite:`campbell2010`:
 .. note::
 
     In :cite:`yaghoubi`, ``severe`` exacerbations are equivalent to our definition of ``very severe``
-    exacerbations. Thus, we are missing the utility of ``severe`` exacerbations. To account for
-    this, we defined the utility of a ``severe`` exacerbation as the arithmetic mean of the
-    utilities of ``moderate`` and ``very severe`` exacerbations:
+    exacerbations. Thus, we are missing the utility of ``severe`` exacerbations. We defined the utility of a ``severe`` exacerbation as the arithmetic mean of the utilities of ``moderate`` and ``very severe`` exacerbations:
 
     .. math::
 
@@ -163,10 +161,10 @@ where:
      - 0.33
      - 0.56
 
-Now, the values listed in this table are the disutility for having an asthma exacerbation of a given
+The values listed in this table are the disutility for having an asthma exacerbation of a given
 severity for an entire year. We assume that a mild asthma exacerbation lasts for 7 days, while
 all the other severity levels last for 14 days :cite:`aldington2007`. To convert these values we
-have the weekly disutility:
+need the weekly disutility:
 
 .. math::
 
@@ -275,31 +273,34 @@ where:
 Model: Calculating Utility
 ===========================
 
-Exacerbation disutility is applied per exacerbation event, i.e. it is incurred each time there is
-an exacerbation of the corresponding severity. Control level disutility is weighted by
-:math:`P(y = k)`, which per the :ref:`control-model` represents the proportion of the time interval
-spent at control level :math:`k`. The net utility is given by the formula:
+Exacerbation disutility is applied per exacerbation event, i.e. it is incurred each time agent
+:math:`i` has an exacerbation of the corresponding severity. Control level disutility is weighted
+by :math:`P(y^{(i)} = k)`, which per the :ref:`control-model` represents the proportion of the time
+interval agent :math:`i` spends at control level :math:`k`. The net utility is given by the
+formula:
 
 .. math::
 
-    u =
+    \small
+    u^{(i)} =
     \begin{cases}
-        u_{\text{age}, \text{sex}} & \text{if the person does not have asthma} \\[6pt]
-        \max\left(0,\ u_{\text{age}, \text{sex}} - \left(
-          \sum_{S=1}^{4} n_{\text{Exac}}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y = k) \cdot d_C(k)
-        \right)\right) & \text{if the person has asthma}
+        u_{\text{age}, \text{sex}}^{(i)} & \text{if agent } i \text{ does not have asthma} \\[6pt]
+        \max\left(0,\ u_{\text{age}, \text{sex}}^{(i)} - \left(
+          \sum_{S=1}^{4} n_{\text{Exac}}^{(i)}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y^{(i)} = k) \cdot d_C(k)
+        \right)\right) & \text{if agent } i \text{ has asthma}
     \end{cases}
 
 where:
 
-* :math:`u_{\text{age}, \text{sex}}` is the baseline utility for a person of the given age and
-  sex (without asthma)
-* :math:`n_{\text{Exac}}(S)` is the number of exacerbations at severity level :math:`S` in a
-  time interval
+* :math:`u_{\text{age}, \text{sex}}^{(i)}` is the baseline utility for agent :math:`i`, of the
+  given age and sex (without asthma)
+* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of exacerbations at severity level :math:`S` in a
+  time interval, for agent :math:`i`
 * :math:`d_E(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
 * :math:`S \in \{\text{mild}, \text{moderate}, \text{severe}, \text{very severe}\}` is the asthma
   exacerbation severity level
-* :math:`P(y = k)` is the probability of being at asthma control level :math:`k`
+* :math:`P(y^{(i)} = k)` is the probability of agent :math:`i` being at asthma control level
+  :math:`k`
 * :math:`d_C(k)` is the disutility due to being at asthma control level :math:`k`
 * :math:`k \in \{\text{well-controlled}, \text{partially-controlled}, \text{uncontrolled}\}` is
   the asthma control level

--- a/docs/model/model-utility.rst
+++ b/docs/model/model-utility.rst
@@ -4,6 +4,10 @@
 Utility Model
 =================
 
+In ``LEAP``, we quantify the health-related quality of life of individuals with asthma using
+**health state utilities**, which range from 0 to 1, where 1 represents perfect health and 0
+represents death.
+
 Datasets
 =================
 
@@ -286,7 +290,7 @@ formula:
     \begin{cases}
         u_{\text{age}, \text{sex}}^{(i)} & \text{if agent } i \text{ does not have asthma} \\[6pt]
         \max\left(0,\ u_{\text{age}, \text{sex}}^{(i)} - \left(
-          \sum_{S=1}^{4} n_{\text{Exac}}^{(i)}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y^{(i)} = k) \cdot d_C(k)
+          \sum_{S=1}^{4} n_E^{(i)}(S) \cdot d_E(S) + \sum_{k=1}^{3} P(y^{(i)} = k) \cdot d_C(k)
         \right)\right) & \text{if agent } i \text{ has asthma}
     \end{cases}
 
@@ -294,7 +298,7 @@ where:
 
 * :math:`u_{\text{age}, \text{sex}}^{(i)}` is the baseline utility for agent :math:`i`, of the
   given age and sex (without asthma)
-* :math:`n_{\text{Exac}}^{(i)}(S)` is the number of exacerbations at severity level :math:`S` in a
+* :math:`n_E^{(i)}(S)` is the number of exacerbations at severity level :math:`S` in a
   time interval, for agent :math:`i`
 * :math:`d_E(S)` is the disutility due to an asthma exacerbation of severity level :math:`S`
 * :math:`S \in \{\text{mild}, \text{moderate}, \text{severe}, \text{very severe}\}` is the asthma


### PR DESCRIPTION
## Description

Updates the utility model documentation (`docs/model/model-utility.rst`) and the corresponding
"Step 8: Compute utility" section in `docs/model/model-simulation.rst`, to make wording changes and bring the notation in line with the recently updated cost model docs (PR #76).

Key changes:
- Documented the linear interpolation method used to fill in EQ-5D utility values for ages 0–17, and fixed the interpolation domain to `[0, 17]` (age 18 is the
  observed anchor point, not interpolated).
- Named and linked the underlying data files (`eq5d_canada.csv`) referenced in the text.
- Corrected the baseline used to convert exacerbation utility values to disutility: verified
  against Lloyd et al. 2007 (Table 2) and the actual runtime `config.json` parameters that the
  correct baseline is `0.89` (mean EQ-5D utility for "no exacerbation"), not the previously
  documented `0.9`. This was cross-checked against three independent sources (the model
  validation paper's payoff section, Yaghoubi et al. Table I, and the `βexac_sev_hist` values
 in `config.json`) and now reconciles exactly.
- Added citations for the exacerbation disutility data (Lloyd et al. 2007,
  Campbell et al. 2010) and the control-level discrete choice experiment (McTaggart-Cowan et al.
  2008)
- Updated the "Model: Calculating Utility" formula (and its duplicate in `model-simulation.rst`)
  to:
  - Use a `\begin{cases}` piecewise definition instead of a boolean-multiplier (`A ·`) term,
    matching the convention already used in `model-control.rst` and
    `model-exacerbation-severity.rst`, and mapping directly onto the `if/else` branch in
    `utility.py`.
  - Add the `max(0, ...)` floor from `utility.py:136`, which was previously undocumented.
  - Add the agent superscript `(i)` to per-agent terms, matching the convention established in
    the cost model docs (PR #76).
- No dependency changes.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

This is a documentation-only change; no code or tests were modified. Verification performed:

- [x] Confirmed the corrected exacerbation disutility values (0.32/0.44/0.50/0.56) reproduce the
      `βexac_sev_hist` values in `leap/processed_data/time_delta_365/config.json` exactly
- [x] Confirmed the corrected `0.89` baseline against Lloyd et al. 2007, Table 2
- [x] Confirmed the utility/disutility numbers match the model validation paper's payoff section
      description
- [x] Visually reviewed the rendered `.. math::` blocks for correct LaTeX syntax

## Linked PRs / Issues

- Related to #76 (Update cost documentation) — the notation conventions in the "Model:
  Calculating Utility" formula were aligned with the conventions established there
  (`n_{\text{Exac}}^{(i)}(S)`, `P(y^{(i)} = k)`, agent superscript `(i)`).

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
