### PR TITLE
Rename "population_growth_type" to "projection_scenario" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To specify the province and population growth scenario:
 
 ```sh
 leap --run-simulation --time-horizon 1 --num-births-initial 10 --max-age 4 --province "CA" \
---min-year 2024 --population-growth-type "M3" --path-output PATH/TO/OUTPUT/FOLDER
+--min-year 2024 --projection-scenario "M3" --path-output PATH/TO/OUTPUT/FOLDER
 ```
 
 If you would like to use your own `config.json` file instead of the default one:

--- a/docs/cli/config.rst
+++ b/docs/cli/config.rst
@@ -16,7 +16,7 @@ The ``config.json`` file contains the parameters used in the simulation.
             "min_year": 2024,
             "time_horizon": 2,
             "province": "BC",
-            "population_growth_type": "LG",
+            "projection_scenario": "LG",
             "num_births_initial": 100,
             "max_age": 111
         },

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -137,7 +137,7 @@ Simulation Arguments
       </tr>
 
       <tr>
-        <td><code class="notranslate">--population-growth-type</code></td>
+        <td><code class="notranslate">--projection-scenario</code></td>
         <td><code class="notranslate">"LG"</code></td>
         <td>The population growth scenario to use. One of:
           <ul>
@@ -159,7 +159,7 @@ Simulation Arguments
         See
         <a href="https://www150.statcan.gc.ca/n1/pub/91-520-x/91-520-x2022001-eng.htm">StatCan</a>.
         For example:
-        <code>--population-growth-type "M3"</code>
+        <code>--projection-scenario "M3"</code>
         </td>
       </tr>
 
@@ -185,7 +185,7 @@ Simulation Arguments
           <code class="notranslate">MAX_AGE-</code><br>
           <code class="notranslate">MIN_YEAR-</code><br>
           <code class="notranslate">TIME_HORIZON-</code><br>
-          <code class="notranslate">POPULATION_GROWTH_TYPE-</code><br>
+          <code class="notranslate">PROJECTION_SCENARIO-</code><br>
           <code class="notranslate">NUM_BIRTHS_INITIAL</code><br>
         </td>
         <td>The name of the output directory where the results will be saved. For example:
@@ -248,7 +248,7 @@ To specify the province and population growth scenario:
 
 .. code-block:: bash
 
-  leap --run-simulation --time-horizon 1 --num-births-initial 10 --max-age 4 --province "CA" --min-year 2024 --population-growth-type "M3" --path-output PATH/TO/OUTPUT
+  leap --run-simulation --time-horizon 1 --num-births-initial 10 --max-age 4 --province "CA" --min-year 2024 --projection-scenario "M3" --path-output PATH/TO/OUTPUT
 
 
 If you would like to use your own ``config.json`` file instead of the default one:

--- a/docs/cli/validation.ipynb
+++ b/docs/cli/validation.ipynb
@@ -100,14 +100,14 @@
     "    --max-age MAX_AGE\n",
     "    --min-year STARTING_YEAR\n",
     "    --time-horizon SIMULATION_LENGTH\n",
-    "    --population-growth-type GROWTH_TYPE\n",
+    "    --projection-scenario PROJECTION_SCENARIO\n",
     "    --num-births-initial N_BIRTHS\n",
     "    --ignore-pollution\n",
     "```\n",
     "\n",
     "**NOTE**: The default simulation folder naming scheme is:\n",
     "\n",
-    "`./leap_output/PROVINCE-MAX_AGE-STARTING_YEAR-SIMULATION_LENGTH-GROWTH_TYPE-N_BIRTHS`\n",
+    "`./leap_output/PROVINCE-MAX_AGE-STARTING_YEAR-SIMULATION_LENGTH-PROJECTION_SCENARIO-N_BIRTHS`\n",
     "\n",
     "For instance, if the model was run with the following parameters:\n",
     "\n",
@@ -117,7 +117,7 @@
     "        \"max_age\": 100,\n",
     "        \"min_year\": 2001,\n",
     "        \"time_horizon\": 15,\n",
-    "        \"population_growth_type\": \"M3\",\n",
+    "        \"projection_scenario\": \"M3\",\n",
     "        \"num_births_initial\": 5000,\n",
     "        \"pollution ignored\": true,\n",
     "        \"max_year\": 2015\n",
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "868fea86",
    "metadata": {},
    "outputs": [
@@ -162,7 +162,7 @@
     "MAX_AGE = 110\n",
     "STARTING_YEAR = 2001\n",
     "SIMULATION_LENGTH = 30\n",
-    "GROWTH_TYPE = \"M3\"\n",
+    "PROJECTION_SCENARIO = \"M3\"\n",
     "N_BIRTHS = 5000\n",
     "\n",
     "# Replace with the path to the folder containing your LEAP output csvs\n",
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 257,
+   "execution_count": null,
    "id": "b5de8740",
    "metadata": {},
    "outputs": [],
@@ -204,7 +204,7 @@
     "target_pop_df_raw = load_population_data(\n",
     "    province=PROVINCE,\n",
     "    starting_year=STARTING_YEAR,\n",
-    "    projection_scenario=GROWTH_TYPE,\n",
+    "    projection_scenario=PROJECTION_SCENARIO,\n",
     "    min_age=0,\n",
     "    max_age=MAX_AGE,\n",
     "    max_year=STARTING_YEAR + SIMULATION_LENGTH - 1\n",
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 259,
+   "execution_count": null,
    "id": "2b8b3ab9",
    "metadata": {},
    "outputs": [
@@ -294,7 +294,7 @@
     "    title=f\"Population Pyramid Comparison<br>\"\n",
     "    + f\"Province: {PROVINCE}<br>\"\n",
     "    + f\"Initial Births in {STARTING_YEAR}: {N_BIRTHS}<br>\"\n",
-    "    + f\"Projection Scenario: {GROWTH_TYPE}\",\n",
+    "    + f\"Projection Scenario: {PROJECTION_SCENARIO}\",\n",
     "    labels={\"n_alive_model\": \"Population\"},\n",
     "    color_discrete_sequence=[\"#999999\"],\n",
     "    height=1000,\n",
@@ -5003,7 +5003,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "env",
+   "display_name": "env (3.10.11)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/cli/validation.ipynb
+++ b/docs/cli/validation.ipynb
@@ -5003,7 +5003,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "env (3.10.11)",
+   "display_name": "env",
    "language": "python",
    "name": "python3"
   },

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -386,7 +386,7 @@ After running ``leap --help``, you should see:
 .. code-block:: bash
 
   usage: leap [-r] [-c CONFIG] [-p PROVINCE] [-ma MAX_AGE] [-my MIN_YEAR] [-th TIME_HORIZON]
-              [-gt POPULATION_GROWTH_TYPE] [-nb NUM_BIRTHS_INITIAL] [-ip] [-o PATH_OUTPUT] [-f]
+              [-gt PROJECTION_SCENARIO] [-nb NUM_BIRTHS_INITIAL] [-ip] [-o PATH_OUTPUT] [-f]
               [-v] [-h]
 
   options:

--- a/docs/model/model-simulation.rst
+++ b/docs/model/model-simulation.rst
@@ -16,7 +16,7 @@ First, let us take a look at the different input parameters:
    * - ``province``
      - The province in Canada to run the simulation. Currently only ``BC`` and ``CA`` are
        supported.
-   * - ``population_growth_type``
+   * - ``projection_scenario``
      - Statistics Canada uses different population growth types to model different population
        growth possibilities.
    * - ``num_births_initial``

--- a/leap/birth.py
+++ b/leap/birth.py
@@ -20,31 +20,31 @@ class Birth:
         self,
         min_timepoint: dt.datetime | None = None,
         province: str | None = None,
-        population_growth_type: str | None = None,
+        projection_scenario: str | None = None,
         max_age: int = 111,
         estimate: DataFrameGroupBy | None = None,
         initial_population: pd.DataFrame | None = None,
         time_delta: dt.timedelta | relativedelta | TimeDelta = TimeDelta(years=1)
     ):
         if estimate is None:
-            if min_timepoint is None or province is None or population_growth_type is None:
+            if min_timepoint is None or province is None or projection_scenario is None:
                 raise ValueError(
-                    "Either min_timepoint, province, and population_growth_type or "
+                    "Either min_timepoint, province, and projection_scenario or "
                     "estimate must be provided."
                 )
             self.estimate = self.load_birth_estimate(
-                min_timepoint, province, population_growth_type, time_delta
+                min_timepoint, province, projection_scenario, time_delta
             )
         else:
             self.estimate = estimate
         if initial_population is None:
-            if min_timepoint is None or province is None or population_growth_type is None:
+            if min_timepoint is None or province is None or projection_scenario is None:
                 raise ValueError(
-                    "Either min_timepoint, province, and population_growth_type or "
+                    "Either min_timepoint, province, and projection_scenario or "
                     "initial_population must be provided."
                 )
             self.initial_population = self.load_population_initial_distribution(
-                min_timepoint, province, population_growth_type, max_age, time_delta
+                min_timepoint, province, projection_scenario, max_age, time_delta
             )
         else:
             self.initial_population = initial_population
@@ -127,7 +127,7 @@ class Birth:
         self,
         min_timepoint: dt.datetime,
         province: str,
-        population_growth_type: str,
+        projection_scenario: str,
         time_delta: dt.timedelta | relativedelta | TimeDelta
     ) -> DataFrameGroupBy:
         """Load the data from ``birth_estimate.csv``.
@@ -136,7 +136,7 @@ class Birth:
             min_timepoint: The year for the data to start at. Must be between ``2000-2065``.
             province: A string indicating the province abbreviation, e.g. ``"BC"``.
                 For all of Canada, set province to ``"CA"``.
-            population_growth_type: Population growth type, one of:
+            projection_scenario: Population growth type, one of:
 
                 * ``past``: historical data
                 * ``LG``: low-growth projection
@@ -187,12 +187,12 @@ class Birth:
         )
         check_timepoint(min_timepoint, df)
         check_province(province)
-        check_projection_scenario(population_growth_type)
+        check_projection_scenario(projection_scenario)
 
         df = df[
             (df["timepoint"] >= min_timepoint) &
             (df["province"] == province) &
-            ((df["projection_scenario"] == population_growth_type) |
+            ((df["projection_scenario"] == projection_scenario) |
              (df["projection_scenario"] == "past"))
         ]
         df["N_relative"] = df["N"] / df.loc[df["timepoint"] == min_timepoint]["N"].values[0]
@@ -203,7 +203,7 @@ class Birth:
         self,
         min_timepoint: dt.datetime,
         province: str,
-        population_growth_type: str,
+        projection_scenario: str,
         max_age: int,
         time_delta: dt.timedelta | relativedelta | TimeDelta
     ) -> pd.DataFrame:
@@ -213,7 +213,7 @@ class Birth:
             min_timepoint: The year for the data to start at. Must be between ``2000-2065``.
             province: A string indicating the province abbreviation, e.g. ``"BC"``.
                 For all of Canada, set province to ``"CA"``.
-            population_growth_type: Population growth type, one of:
+            projection_scenario: Population growth type, one of:
 
                 * ``past``: historical data
                 * ``LG``: low-growth projection
@@ -242,13 +242,13 @@ class Birth:
 
         check_timepoint(min_timepoint, df)
         check_province(province)
-        check_projection_scenario(population_growth_type)
+        check_projection_scenario(projection_scenario)
 
         df = df[
             (df["age"] <= max_age) &
             (df["timepoint"] == min_timepoint) &
             (df["province"] == province) &
-            ((df["projection_scenario"] == population_growth_type) |
+            ((df["projection_scenario"] == projection_scenario) |
              (df["projection_scenario"] == "past"))
         ]
         return df
@@ -275,7 +275,7 @@ class Birth:
             >>> birth = Birth(
             ...     min_timepoint=dt.datetime(2000, 1, 1),
             ...     province="CA",
-            ...     population_growth_type="LG",
+            ...     projection_scenario="LG",
             ...     initial_population=initial_population
             ... )
             >>> birth.get_initial_population_indices(num_births=2)
@@ -308,7 +308,7 @@ class Birth:
             >>> birth = Birth(
             ...     min_timepoint=dt.datetime(2000, 1, 1),
             ...     province="CA",
-            ...     population_growth_type="LG"
+            ...     projection_scenario="LG"
             ... )
             >>> birth.get_num_newborn(num_births_initial=100, timepoint=dt.datetime(2000, 1, 1))
             100

--- a/leap/emigration.py
+++ b/leap/emigration.py
@@ -20,13 +20,13 @@ class Emigration:
         self,
         min_timepoint: dt.datetime = dt.datetime(2000, 1, 1),
         province: str = "CA",
-        population_growth_type: str = "LG",
+        projection_scenario: str = "LG",
         table: DataFrameGroupBy | None = None,
         time_delta: dt.timedelta | relativedelta | TimeDelta = TimeDelta(years=1)
     ):
         if table is None:
             self.table = self.load_emigration_table(
-                min_timepoint, province, population_growth_type, time_delta
+                min_timepoint, province, projection_scenario, time_delta
             )
         else:
             self.table = table
@@ -54,7 +54,7 @@ class Emigration:
         self,
         min_timepoint: dt.datetime,
         province: str,
-        population_growth_type: str,
+        projection_scenario: str,
         time_delta: dt.timedelta | relativedelta | TimeDelta
     ) -> DataFrameGroupBy:
         """Load the data from ``processed_data/{time_delta_tag}/migration/migration_table.csv``.
@@ -64,7 +64,7 @@ class Emigration:
                 or 2001-2043 (BC).
             province: a string indicating the province abbreviation, e.g. "BC".
                 For all of Canada, set province to "CA".
-            population_growth_type: Population growth type, one of:
+            projection_scenario: Population growth type, one of:
 
                 * ``past``: historical data
                 * ``LG``: low-growth projection
@@ -91,13 +91,13 @@ class Emigration:
             parse_dates=["timepoint"]
         )
         check_province(province)
-        check_projection_scenario(population_growth_type)
+        check_projection_scenario(projection_scenario)
         check_timepoint(min_timepoint + time_delta, df[df["province"] == province])
 
         df = df[
             (df["timepoint"] >= min_timepoint) &
             (df["province"] == province) &
-            (df["projection_scenario"] == population_growth_type)
+            (df["projection_scenario"] == projection_scenario)
         ]
 
         df.drop(columns=["province", "projection_scenario"], inplace=True)

--- a/leap/immigration.py
+++ b/leap/immigration.py
@@ -20,14 +20,14 @@ class Immigration:
         self,
         min_timepoint: dt.datetime = dt.datetime(2000, 1, 1),
         province: str = "CA",
-        population_growth_type: str = "LG",
+        projection_scenario: str = "LG",
         max_age: int = 111,
         table: DataFrameGroupBy | None = None,
         time_delta: relativedelta | dt.timedelta | TimeDelta = TimeDelta(years=1)
     ):
         if table is None:
             self.table = self.load_immigration_table(
-                min_timepoint, province, population_growth_type, max_age, time_delta
+                min_timepoint, province, projection_scenario, max_age, time_delta
             )
         else:
             self.table = table
@@ -58,7 +58,7 @@ class Immigration:
         self,
         min_timepoint: dt.datetime,
         province: str,
-        population_growth_type: str,
+        projection_scenario: str,
         max_age: int,
         time_delta: dt.timedelta | relativedelta | TimeDelta
     ) -> DataFrameGroupBy:
@@ -69,7 +69,7 @@ class Immigration:
                 (CA) or ``2001-2043`` (BC).
             province: A string indicating the province abbreviation, e.g. ``"BC"``.
                 For all of Canada, set province to ``"CA"``.
-            population_growth_type: Population growth type, one of:
+            projection_scenario: Population growth type, one of:
 
                 * ``past``: historical data
                 * ``LG``: low-growth projection
@@ -98,7 +98,7 @@ class Immigration:
             parse_dates=["timepoint"]
         )
         check_province(province)
-        check_projection_scenario(population_growth_type)
+        check_projection_scenario(projection_scenario)
         check_timepoint(min_timepoint + time_delta, df[df["province"] == province])
 
         df = df[
@@ -106,7 +106,7 @@ class Immigration:
             (df["age"] <= max_age) &
             (df["timepoint"] >= min_timepoint) &
             (df["province"] == province) &
-            (df["projection_scenario"] == population_growth_type)
+            (df["projection_scenario"] == projection_scenario)
         ]
         df = df.drop(
             columns=[
@@ -139,7 +139,7 @@ class Immigration:
             >>> from leap.immigration import Immigration
             >>> import datetime as dt
             >>> immigration = Immigration(
-            ...     min_timepoint=dt.datetime(2000, 1, 1), province="BC", population_growth_type="LG"
+            ...     min_timepoint=dt.datetime(2000, 1, 1), province="BC", projection_scenario="LG"
             ... )
             >>> n_immigrants = immigration.get_num_new_immigrants(
             ...     num_new_born=1000, timepoint=dt.datetime(2022, 1, 1)

--- a/leap/main.py
+++ b/leap/main.py
@@ -89,8 +89,8 @@ def get_parser() -> argparse.ArgumentParser:
     )
     args.add_argument(
         "-gt",
-        "--population-growth-type",
-        dest="population_growth_type",
+        "--projection-scenario",
+        dest="projection_scenario",
         required=False,
         type=str,
         help="""Population growth type for the simulation. Must be one of:
@@ -320,7 +320,7 @@ def run_main():
         time_horizon=(
             TimeDelta(years=args.time_horizon) if args.time_horizon is not None else None
         ),
-        population_growth_type=args.population_growth_type,
+        projection_scenario=args.projection_scenario,
         num_births_initial=args.num_births_initial,
         ignore_pollution_flag=args.ignore_pollution,
     )
@@ -329,7 +329,7 @@ def run_main():
     # Check if path_output argument is supplied or not
     if args.path_output is None or args.path_output == "":
         # Default dir name based on simulation arguments
-        dir_name = f"{simulation.province}-{simulation.max_age}-{simulation.min_timepoint.year}-{simulation.time_horizon.years}-{simulation.population_growth_type}-{simulation.num_births_initial}"
+        dir_name = f"{simulation.province}-{simulation.max_age}-{simulation.min_timepoint.year}-{simulation.time_horizon.years}-{simulation.projection_scenario}-{simulation.num_births_initial}"
     else:
         # Get the name of the dir to store outputs in
         dir_name = args.path_output
@@ -388,7 +388,7 @@ def run_main():
         "max_age": simulation.max_age,
         "min_year": simulation.min_timepoint.year,
         "time_horizon": simulation.time_horizon.years,
-        "population_growth_type": simulation.population_growth_type,
+        "projection_scenario": simulation.projection_scenario,
         "num_births_initial": simulation.num_births_initial,
         "pollution ignored": args.ignore_pollution,
         "max_year": simulation.max_timepoint.year,

--- a/leap/processed_data/time_delta_365/config.json
+++ b/leap/processed_data/time_delta_365/config.json
@@ -3,7 +3,7 @@
         "min_timepoint": "2024-01-01 00:00:00",
         "time_horizon": "P2Y",
         "province": "BC",
-        "population_growth_type": "LG",
+        "projection_scenario": "LG",
         "num_births_initial": 100,
         "max_age": 111,
         "until_all_die": false,

--- a/leap/simulation.py
+++ b/leap/simulation.py
@@ -51,7 +51,7 @@ class Simulation:
         max_age: int | None = None,
         min_timepoint: dt.datetime | None = None,
         time_horizon: dt.timedelta | None = None,
-        population_growth_type: str | None = None,
+        projection_scenario: str | None = None,
         num_births_initial: int | None = None,
         until_all_die: bool | None = None,
         ignore_pollution_flag: bool = False,
@@ -87,10 +87,10 @@ class Simulation:
             self.time_horizon = time_horizon
         else:
             self.time_horizon = TimeDelta(iso_string=config["simulation"]["time_horizon"])
-        if population_growth_type is not None:
-            self.population_growth_type = population_growth_type
+        if projection_scenario is not None:
+            self.projection_scenario = projection_scenario
         else:
-            self.population_growth_type = config["simulation"]["population_growth_type"]
+            self.projection_scenario = config["simulation"]["projection_scenario"]
         if num_births_initial is not None:
             self.num_births_initial = num_births_initial
         else:
@@ -100,12 +100,12 @@ class Simulation:
         else:
             self.until_all_die = config["simulation"]["until_all_die"]
         self.agent = None
-        self.birth = Birth(self.min_timepoint, self.province, self.population_growth_type, self.max_age)
-        self.emigration = Emigration(self.min_timepoint, self.province, self.population_growth_type)
+        self.birth = Birth(self.min_timepoint, self.province, self.projection_scenario, self.max_age)
+        self.emigration = Emigration(self.min_timepoint, self.province, self.projection_scenario)
         self.immigration = Immigration(
-            self.min_timepoint, self.province, self.population_growth_type, self.max_age
+            self.min_timepoint, self.province, self.projection_scenario, self.max_age
         )
-        self.death = Death(self.province, self.population_growth_type, self.min_timepoint)
+        self.death = Death(self.province, self.projection_scenario, self.min_timepoint)
         self.incidence = Incidence(config["incidence"])
         self.prevalence = Prevalence(config["prevalence"])
         self.reassessment = Reassessment(self.min_timepoint, self.province)
@@ -129,7 +129,7 @@ class Simulation:
             f"max_age={self.max_age}, "
             f"min_timepoint={self.min_timepoint}, "
             f"time_horizon={self.time_horizon}, "
-            f"population_growth_type='{self.population_growth_type}')"
+            f"projection_scenario='{self.projection_scenario}')"
             f"num_births_initial={self.num_births_initial}, "
         )
 
@@ -233,7 +233,7 @@ class Simulation:
             self.max_time_horizon = self.time_horizon
 
     @property
-    def population_growth_type(self) -> str:
+    def projection_scenario(self) -> str:
         """Population growth type to be used in the simulation.
 
         One of:
@@ -252,11 +252,11 @@ class Simulation:
 
         See `StatCan <https://www150.statcan.gc.ca/n1/pub/91-520-x/91-520-x2022001-eng.htm>`_.
         """
-        return self._population_growth_type
+        return self._projection_scenario
 
-    @population_growth_type.setter
-    def population_growth_type(self, population_growth_type: str):
-        self._population_growth_type = population_growth_type
+    @projection_scenario.setter
+    def projection_scenario(self, projection_scenario: str):
+        self._projection_scenario = projection_scenario
 
     @property
     def num_births_initial(self) -> int:

--- a/tests/data/config.json
+++ b/tests/data/config.json
@@ -3,7 +3,7 @@
         "min_timepoint": "2001-01-01 00:00:00",
         "time_horizon": "P19Y",
         "province": "BC",
-        "population_growth_type": "LG",
+        "projection_scenario": "LG",
         "num_births_initial": 100,
         "max_age": 111,
         "until_all_die": false,

--- a/tests/test_birth.py
+++ b/tests/test_birth.py
@@ -9,7 +9,7 @@ logger = get_logger(__name__)
 
 
 @pytest.mark.parametrize(
-    "min_timepoint, province, population_growth_type, expected_N, expected_prop_male",
+    "min_timepoint, province, projection_scenario, expected_N, expected_prop_male",
     [
         (
             dt.datetime(2022, 1, 1),
@@ -21,25 +21,25 @@ logger = get_logger(__name__)
     ]
 )
 def test_birth_constructor(
-    min_timepoint, province, population_growth_type, expected_N, expected_prop_male
+    min_timepoint, province, projection_scenario, expected_N, expected_prop_male
 ):
     birth = Birth(
         min_timepoint=min_timepoint,
         province=province,
-        population_growth_type=population_growth_type
+        projection_scenario=projection_scenario
     )
 
     assert birth.estimate.get_group(min_timepoint)["N_relative"].iloc[0] == 1.0
     assert birth.estimate["province"].get_group(min_timepoint).iloc[0] == province
     assert birth.estimate.get_group(min_timepoint)["N"].iloc[0] == expected_N
     assert round_number(birth.estimate.get_group(min_timepoint)["prop_male"].iloc[0], sigdigits=5) == expected_prop_male
-    assert birth.estimate.get_group(min_timepoint)["projection_scenario"].iloc[0] == population_growth_type
+    assert birth.estimate.get_group(min_timepoint)["projection_scenario"].iloc[0] == projection_scenario
     assert birth.estimate.get_group(min_timepoint)["timepoint"].iloc[0] == min_timepoint
 
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, province, population_growth_type, max_age, initial_population,"
+        "min_timepoint, province, projection_scenario, max_age, initial_population,"
         "expected_indices"
     ),
     [
@@ -54,13 +54,13 @@ def test_birth_constructor(
     ]
 )
 def test_birth_get_initial_population_indices(
-    min_timepoint, province, population_growth_type, max_age, initial_population, expected_indices
+    min_timepoint, province, projection_scenario, max_age, initial_population, expected_indices
 ):
 
     birth = Birth(
         min_timepoint=min_timepoint,
         province=province,
-        population_growth_type=population_growth_type
+        projection_scenario=projection_scenario
     )
     birth.initial_population = initial_population
     initial_pop_indices = birth.get_initial_population_indices(max_age)
@@ -69,7 +69,7 @@ def test_birth_get_initial_population_indices(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, province, population_growth_type, max_age, timepoint, num_births_initial,"
+        "min_timepoint, province, projection_scenario, max_age, timepoint, num_births_initial,"
         "expected_num_newborn"
     ),
     [
@@ -85,14 +85,14 @@ def test_birth_get_initial_population_indices(
     ]
 )
 def test_birth_get_num_newborn(
-    min_timepoint, province, population_growth_type, max_age, timepoint, num_births_initial,
+    min_timepoint, province, projection_scenario, max_age, timepoint, num_births_initial,
     expected_num_newborn
 ):
 
     birth = Birth(
         min_timepoint=min_timepoint,
         province=province,
-        population_growth_type=population_growth_type
+        projection_scenario=projection_scenario
     )
     num_new_born = birth.get_num_newborn(num_births_initial, timepoint)
     assert num_new_born == expected_num_newborn

--- a/tests/test_emigration.py
+++ b/tests/test_emigration.py
@@ -5,7 +5,7 @@ from leap.utils import round_number
 
 
 @pytest.mark.parametrize(
-    "min_timepoint, timepoint, age, sex, province, population_growth_type, value",
+    "min_timepoint, timepoint, age, sex, province, projection_scenario, value",
     [
         (
             dt.datetime(2024, 1, 1),
@@ -19,12 +19,12 @@ from leap.utils import round_number
     ]
 )
 def test_emigration_constructor(
-    min_timepoint, timepoint, age, sex, province, population_growth_type, value
+    min_timepoint, timepoint, age, sex, province, projection_scenario, value
 ):
     emigration = Emigration(
         min_timepoint=min_timepoint,
         province=province,
-        population_growth_type=population_growth_type
+        projection_scenario=projection_scenario
     )
 
     df = emigration.table.get_group((timepoint))
@@ -36,7 +36,7 @@ def test_emigration_constructor(
 
 
 @pytest.mark.parametrize(
-    "min_timepoint, timepoint, age, sex, province, population_growth_type, lower_bound, upper_bound",
+    "min_timepoint, timepoint, age, sex, province, projection_scenario, lower_bound, upper_bound",
     [
         (
             dt.datetime(2020, 1, 1),
@@ -61,7 +61,7 @@ def test_emigration_constructor(
     ]
 )
 def test_emigration_compute_probability(
-    min_timepoint, timepoint, age, sex, province, population_growth_type, lower_bound, upper_bound
+    min_timepoint, timepoint, age, sex, province, projection_scenario, lower_bound, upper_bound
 ):
     """Test the ``compute_probability`` method of the ``Emigration`` class.
     
@@ -75,7 +75,7 @@ def test_emigration_compute_probability(
     emigration = Emigration(
         min_timepoint=min_timepoint,
         province=province,
-        population_growth_type=population_growth_type
+        projection_scenario=projection_scenario
     )
 
     count = 0

--- a/tests/test_immigration.py
+++ b/tests/test_immigration.py
@@ -6,7 +6,7 @@ from leap.utils import round_number
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, timepoint, age, max_age, sex, province, population_growth_type,"
+        "min_timepoint, timepoint, age, max_age, sex, province, projection_scenario,"
         "prop_immigrants_birth, prop_immigrants_timepoint"
     ),
     [
@@ -35,13 +35,13 @@ from leap.utils import round_number
     ]
 )
 def test_immigration_constructor(
-    min_timepoint, timepoint, age, max_age, sex, province, population_growth_type,
+    min_timepoint, timepoint, age, max_age, sex, province, projection_scenario,
     prop_immigrants_birth, prop_immigrants_timepoint
 ):
     immigration = Immigration(
         min_timepoint=min_timepoint,
         province=province,
-        population_growth_type=population_growth_type,
+        projection_scenario=projection_scenario,
         max_age=max_age
     )
     df = immigration.table.get_group((timepoint))
@@ -52,7 +52,7 @@ def test_immigration_constructor(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, timepoint, max_age, province, population_growth_type,"
+        "min_timepoint, timepoint, max_age, province, projection_scenario,"
         "num_new_born, num_new_immigrants"
     ),
     [
@@ -68,13 +68,13 @@ def test_immigration_constructor(
     ]
 )
 def test_immigration_get_num_new_immigrants(
-    min_timepoint, timepoint, max_age, province, population_growth_type, num_new_born,
+    min_timepoint, timepoint, max_age, province, projection_scenario, num_new_born,
     num_new_immigrants
 ):
     immigration = Immigration(
         min_timepoint=min_timepoint,
         province=province,
-        population_growth_type=population_growth_type,
+        projection_scenario=projection_scenario,
         max_age=max_age
     )
     assert immigration.get_num_new_immigrants(num_new_born, timepoint) == num_new_immigrants

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -24,7 +24,7 @@ def config():
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, time_horizon, province, population_growth_type, num_births_initial, max_age,"
+        "min_timepoint, time_horizon, province, projection_scenario, num_births_initial, max_age,"
         "antibiotic_exposure_parameters, prevalence_parameters, incidence_parameter_β_fam_hist,"
         "family_history_parameters, exacerbation_hyperparameter_β0_μ, control_parameter_θ,"
         "sex, age, timepoint_index,"
@@ -130,7 +130,7 @@ def config():
     ]
 )
 def test_simulation_generate_initial_asthma(
-    config, min_timepoint, time_horizon, province, population_growth_type, num_births_initial, max_age,
+    config, min_timepoint, time_horizon, province, projection_scenario, num_births_initial, max_age,
     antibiotic_exposure_parameters, prevalence_parameters, incidence_parameter_β_fam_hist,
     family_history_parameters, exacerbation_hyperparameter_β0_μ, control_parameter_θ,
     sex, age, timepoint_index, expected_has_asthma, expected_asthma_age, expected_asthma_status,
@@ -164,7 +164,7 @@ def test_simulation_generate_initial_asthma(
         "min_timepoint": min_timepoint,
         "time_horizon": str(time_horizon),
         "province": province,
-        "population_growth_type": population_growth_type,
+        "projection_scenario": projection_scenario,
         "num_births_initial": num_births_initial,
         "max_age": max_age,
         "until_all_die": False,
@@ -199,7 +199,7 @@ def test_simulation_generate_initial_asthma(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, time_horizon, time_delta, province, population_growth_type, num_births_initial, max_age,"
+        "min_timepoint, time_horizon, time_delta, province, projection_scenario, num_births_initial, max_age,"
         "antibiotic_exposure_parameters, incidence_parameter_β_fam_hist,"
         "incidence_parameter_βabx_exp, family_history_parameters, sex, age, timepoint_index,"
         "expected_agent_has_asthma, expected_asthma_age, expected_asthma_status,"
@@ -281,7 +281,7 @@ def test_simulation_generate_initial_asthma(
     ]
 )
 def test_check_if_agent_gets_new_asthma_diagnosis(
-    config, min_timepoint, time_horizon, time_delta, province, population_growth_type,
+    config, min_timepoint, time_horizon, time_delta, province, projection_scenario,
     num_births_initial, max_age, antibiotic_exposure_parameters, incidence_parameter_β_fam_hist,
     incidence_parameter_βabx_exp, family_history_parameters, sex, age, timepoint_index,
     expected_agent_has_asthma, expected_asthma_age, expected_asthma_status, expected_asthma_incidence
@@ -311,7 +311,7 @@ def test_check_if_agent_gets_new_asthma_diagnosis(
         "min_timepoint": min_timepoint,
         "time_horizon": str(time_horizon),
         "province": province,
-        "population_growth_type": population_growth_type,
+        "projection_scenario": projection_scenario,
         "num_births_initial": num_births_initial,
         "max_age": max_age,
         "until_all_die": False,
@@ -357,7 +357,7 @@ def test_check_if_agent_gets_new_asthma_diagnosis(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, time_horizon, time_delta, province, population_growth_type, num_births_initial, max_age,"
+        "min_timepoint, time_horizon, time_delta, province, projection_scenario, num_births_initial, max_age,"
         "antibiotic_exposure_parameters, incidence_parameter_β_fam_hist,"
         "family_history_parameters, exacerbation_hyperparameter_β0_μ, control_parameter_θ,"
         "sex, age, has_asthma, asthma_age, asthma_status, expected_control_levels,"
@@ -415,7 +415,7 @@ def test_check_if_agent_gets_new_asthma_diagnosis(
     ]
 )              
 def test_simulation_update_asthma_effects(
-    config, min_timepoint, time_horizon, time_delta, province, population_growth_type,
+    config, min_timepoint, time_horizon, time_delta, province, projection_scenario,
     num_births_initial, max_age,
     antibiotic_exposure_parameters, incidence_parameter_β_fam_hist, family_history_parameters,
     control_parameter_θ, exacerbation_hyperparameter_β0_μ, sex, age, has_asthma, asthma_age,
@@ -450,7 +450,7 @@ def test_simulation_update_asthma_effects(
         "min_timepoint": min_timepoint,
         "time_horizon": str(time_horizon),
         "province": province,
-        "population_growth_type": population_growth_type,
+        "projection_scenario": projection_scenario,
         "num_births_initial": num_births_initial,
         "max_age": max_age,
         "until_all_die": False,
@@ -501,7 +501,7 @@ def test_simulation_update_asthma_effects(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, time_horizon, time_delta, province, population_growth_type, num_births_initial, max_age,"
+        "min_timepoint, time_horizon, time_delta, province, projection_scenario, num_births_initial, max_age,"
         "antibiotic_exposure_parameters, incidence_parameter_β_fam_hist,"
         "family_history_parameters, exacerbation_hyperparameter_β0_μ, control_parameter_θ,"
         "sex, age, has_asthma, asthma_age, asthma_status, exacerbation_history, timepoint_index,"
@@ -543,7 +543,7 @@ def test_simulation_update_asthma_effects(
     ]
 )
 def test_reassess_asthma_diagnosis(
-    config, min_timepoint, time_horizon, time_delta, province, population_growth_type,
+    config, min_timepoint, time_horizon, time_delta, province, projection_scenario,
     num_births_initial, max_age,
     antibiotic_exposure_parameters, incidence_parameter_β_fam_hist, family_history_parameters,
     exacerbation_hyperparameter_β0_μ, control_parameter_θ, sex, age, has_asthma, asthma_age,
@@ -578,7 +578,7 @@ def test_reassess_asthma_diagnosis(
         "min_timepoint": min_timepoint,
         "time_horizon": str(time_horizon),
         "province": province,
-        "population_growth_type": population_growth_type,
+        "projection_scenario": projection_scenario,
         "num_births_initial": num_births_initial,
         "max_age": max_age,
         "until_all_die": False,
@@ -638,7 +638,7 @@ def test_reassess_asthma_diagnosis(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, time_horizon, time_delta, province, population_growth_type,"
+        "min_timepoint, time_horizon, time_delta, province, projection_scenario,"
         "num_births_initial, max_age, timepoint, n_new_agents, expected_immigrants"
     ),
     [
@@ -669,7 +669,7 @@ def test_reassess_asthma_diagnosis(
     ]
 )
 def test_simulation_get_new_agents(
-    config, min_timepoint, time_horizon, time_delta, province, population_growth_type,
+    config, min_timepoint, time_horizon, time_delta, province, projection_scenario,
     num_births_initial, max_age, timepoint, n_new_agents, expected_immigrants
 ):
 
@@ -677,7 +677,7 @@ def test_simulation_get_new_agents(
         "min_timepoint": min_timepoint,
         "time_horizon": str(time_horizon),
         "province": province,
-        "population_growth_type": population_growth_type,
+        "projection_scenario": projection_scenario,
         "num_births_initial": num_births_initial,
         "max_age": max_age,
         "until_all_die": False,
@@ -697,7 +697,7 @@ def test_simulation_get_new_agents(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, time_horizon, time_delta, province, population_growth_type, num_births_initial, max_age,"
+        "min_timepoint, time_horizon, time_delta, province, projection_scenario, num_births_initial, max_age,"
         "antibiotic_exposure_parameters, incidence_parameter_β_fam_hist,"
         "family_history_parameters, exacerbation_hyperparameter_β0_μ, control_parameter_θ,"
         "prevalence_parameters, utility_parameters, cost_parameters,"
@@ -820,7 +820,7 @@ def test_simulation_get_new_agents(
     [0, MIN_AGENTS_MP]
 )
 def test_run_simulation_one_year(
-    config, min_agents_mp, min_timepoint, time_horizon, time_delta, province, population_growth_type,
+    config, min_agents_mp, min_timepoint, time_horizon, time_delta, province, projection_scenario,
     num_births_initial, max_age, antibiotic_exposure_parameters, incidence_parameter_β_fam_hist,
     family_history_parameters, exacerbation_hyperparameter_β0_μ, control_parameter_θ,
     prevalence_parameters, utility_parameters, cost_parameters, timepoint_index,
@@ -881,7 +881,7 @@ def test_run_simulation_one_year(
         "min_timepoint": min_timepoint,
         "time_horizon": str(time_horizon),
         "province": province,
-        "population_growth_type": population_growth_type,
+        "projection_scenario": projection_scenario,
         "num_births_initial": num_births_initial,
         "max_age": max_age,
         "until_all_die": False,
@@ -953,7 +953,7 @@ def test_run_simulation_one_year(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, time_horizon, time_delta, province, population_growth_type, num_births_initial, max_age,"
+        "min_timepoint, time_horizon, time_delta, province, projection_scenario, num_births_initial, max_age,"
         "antibiotic_exposure_parameters, incidence_parameter_β_fam_hist,"
         "family_history_parameters, exacerbation_hyperparameter_β0_μ, control_parameter_θ,"
         "prevalence_parameters, cost_parameters,"
@@ -1070,7 +1070,7 @@ def test_run_simulation_one_year(
 )
 def test_run_simulation_two_years(
     config, min_agents_mp, min_timepoint, time_horizon, time_delta, 
-    province, population_growth_type, num_births_initial, max_age,
+    province, projection_scenario, num_births_initial, max_age,
     antibiotic_exposure_parameters, incidence_parameter_β_fam_hist, family_history_parameters,
     exacerbation_hyperparameter_β0_μ, control_parameter_θ, prevalence_parameters,
     cost_parameters, expected_alive, expected_antibiotic_exposure, expected_asthma_cost,
@@ -1108,7 +1108,7 @@ def test_run_simulation_two_years(
         "min_timepoint": min_timepoint,
         "time_horizon": str(time_horizon),
         "province": province,
-        "population_growth_type": population_growth_type,
+        "projection_scenario": projection_scenario,
         "num_births_initial": num_births_initial,
         "max_age": max_age,
         "until_all_die": False,
@@ -1214,7 +1214,7 @@ def test_run_simulation_two_years(
 
 @pytest.mark.parametrize(
     (
-        "min_timepoint, time_horizon, time_delta, province, population_growth_type, num_births_initial, max_age,"
+        "min_timepoint, time_horizon, time_delta, province, projection_scenario, num_births_initial, max_age,"
     ),
     [
         (
@@ -1233,7 +1233,7 @@ def test_run_simulation_two_years(
     [0, MIN_AGENTS_MP]
 )
 def test_run_simulation_full(
-    config, min_agents_mp, min_timepoint, time_horizon, time_delta, province, population_growth_type,
+    config, min_agents_mp, min_timepoint, time_horizon, time_delta, province, projection_scenario,
     num_births_initial, max_age
 ):
 
@@ -1241,7 +1241,7 @@ def test_run_simulation_full(
         "min_timepoint": min_timepoint,
         "time_horizon": str(time_horizon),
         "province": province,
-        "population_growth_type": population_growth_type,
+        "projection_scenario": projection_scenario,
         "num_births_initial": num_births_initial,
         "max_age": max_age,
         "until_all_die": False,


### PR DESCRIPTION
## Description

Currently, there are two variable names being used to describe the same feature: `population_growth_type` and `projection_scenario`. This is unnecessarily confusing; they should both be called the same thing. So, I decided to use `projection_scenario`. In this PR I've renamed every instance of `population_growth_type` to `projection_scenario`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [x] Refactoring (changes in the design of the code that don't change the functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
