### PR TITLE
Timepoint class

### DIFF
--- a/.github/workflows/tests_workflow.yml
+++ b/.github/workflows/tests_workflow.yml
@@ -108,6 +108,10 @@ jobs:
         run: |
           pytest tests/test_utility.py
         continue-on-error: false
+      - name: Run Python tests utils
+        run: |
+          pytest tests/test_utils.py
+        continue-on-error: false
       - name: Run doctests
         run: |
           TQDM_DISABLE=1 pytest leap/ --doctest-modules --ignore=leap/data_generation

--- a/.github/workflows/tests_workflow_full.yml
+++ b/.github/workflows/tests_workflow_full.yml
@@ -111,6 +111,10 @@ jobs:
         run: |
           pytest tests/test_utility.py
         continue-on-error: false
+      - name: Run Python tests utils
+        run: |
+          pytest tests/test_utils.py
+        continue-on-error: false
       - name: Run Python tests birth data generation
         run: |
           pytest tests/test_birth_data.py

--- a/leap/utils.py
+++ b/leap/utils.py
@@ -584,8 +584,8 @@ class Timepoint(dt.datetime):
             minute=timepoint.minute,
             second=timepoint.second,
             microsecond=timepoint.microsecond,
-            tzinfo=timepoint.tzinfo
-        )
+            tzinfo=timepoint.tzinfo,
+            fold=timepoint.fold,
 
     def __hash__(self):
         return hash((self.year, self.month))

--- a/leap/utils.py
+++ b/leap/utils.py
@@ -540,6 +540,46 @@ class Sex:
             return self._value_bool == value
 
 
+
+class Timepoint(dt.datetime):
+    """A class to handle the timepoint variable."""
+
+    def __new__(
+        cls,
+        year: int,
+        month: int,
+        day: int,
+        hour: int = 0,
+        minute: int = 0,
+        second: int = 0,
+        microsecond: int = 0,
+        tzinfo: dt.tzinfo | None = None,
+        *,
+        fold: int = 0
+    ) -> Timepoint:
+
+        self = super().__new__(
+            cls, year, month, day, hour, minute, second, microsecond, tzinfo, fold=fold
+        )
+        return self
+
+    @classmethod
+    def from_datetime(cls, timepoint: dt.datetime) -> Timepoint:
+        """Construct a Timepoint instance from a datetime object."""
+        return cls(
+            year=timepoint.year,
+            month=timepoint.month,
+            day=timepoint.day,
+            minute=timepoint.minute,
+            second=timepoint.second,
+            microsecond=timepoint.microsecond,
+            tzinfo=timepoint.tzinfo
+        )
+
+    def __hash__(self):
+        return hash((self.year, self.month))
+
+
 def date_range(
     start: dt.datetime, stop: dt.datetime, step: dt.timedelta | relativedelta | TimeDelta
 ) -> Generator[dt.datetime, None, None]:

--- a/leap/utils.py
+++ b/leap/utils.py
@@ -565,7 +565,17 @@ class Timepoint(dt.datetime):
 
     @classmethod
     def from_datetime(cls, timepoint: dt.datetime) -> Timepoint:
-        """Construct a Timepoint instance from a datetime object."""
+        """Construct a Timepoint instance from a datetime object.
+
+        Args:
+            timepoint: A ``dt.datetime`` object to convert into a Timepoint instance.
+        
+        Examples:
+
+            >>> timepoint = Timepoint.from_datetime(dt.datetime(2024, 6, 1, 12, 30))
+            >>> print(timepoint)
+            2024-06-01 12:30:00
+        """
         return cls(
             year=timepoint.year,
             month=timepoint.month,

--- a/leap/utils.py
+++ b/leap/utils.py
@@ -570,6 +570,7 @@ class Timepoint(dt.datetime):
             year=timepoint.year,
             month=timepoint.month,
             day=timepoint.day,
+            hour=timepoint.hour,
             minute=timepoint.minute,
             second=timepoint.second,
             microsecond=timepoint.microsecond,

--- a/leap/utils.py
+++ b/leap/utils.py
@@ -585,7 +585,8 @@ class Timepoint(dt.datetime):
             second=timepoint.second,
             microsecond=timepoint.microsecond,
             tzinfo=timepoint.tzinfo,
-            fold=timepoint.fold,
+            fold=timepoint.fold
+        )
 
     def __hash__(self):
         return hash((self.year, self.month))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,43 @@
+import pytest
+import pathlib
+import json
+import numpy as np
+import datetime as dt
+from leap.utils import Timepoint
+
+
+
+@pytest.mark.parametrize(
+    "year, month, day, hour, minute, second, microsecond",
+    [
+        (2024, 6, 1, 12, 30, 0, 0),
+    ]
+)
+def test_timepoint_constructor(year, month, day, hour, minute, second, microsecond):
+    timepoint = Timepoint(year, month, day, hour, minute, second, microsecond)
+    assert timepoint.year == year
+    assert timepoint.month == month
+    assert timepoint.day == day
+    assert timepoint.hour == hour
+    assert timepoint.minute == minute
+    assert timepoint.second == second
+    assert timepoint.microsecond == microsecond
+
+
+@pytest.mark.parametrize(
+    "year, month, day, hour, minute, second, microsecond",
+    [
+        (2024, 6, 1, 12, 30, 0, 0),
+    ]
+)
+def test_timepoint_from_datetime(year, month, day, hour, minute, second, microsecond):
+    dt_obj = dt.datetime(year, month, day, hour, minute, second, microsecond)
+    timepoint = Timepoint.from_datetime(dt_obj)
+    assert isinstance(timepoint, Timepoint)
+    assert timepoint.year == dt_obj.year
+    assert timepoint.month == dt_obj.month
+    assert timepoint.day == dt_obj.day
+    assert timepoint.hour == dt_obj.hour
+    assert timepoint.minute == dt_obj.minute
+    assert timepoint.second == dt_obj.second
+    assert timepoint.microsecond == dt_obj.microsecond


### PR DESCRIPTION
## Description

In this PR I have created a class called `Timepoint` which inherits from `datetime.datetime`. The motivation for this was that I needed to merge on timepoint in a Pandas dataframe, and the `datetime` object doesn't work well for that.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

- [x] `leap/utils.py`: `from_datetime` doctests
- [x] `tests/test_utils.py`: `test_timepoint_constructor`
- [x] `tests/test_utils.py`: `test_timepoint_from_datetime`

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
