### PR TITLE
Timepoint Conversion to Numeric

### DIFF
--- a/.github/workflows/tests_workflow_full.yml
+++ b/.github/workflows/tests_workflow_full.yml
@@ -123,6 +123,10 @@ jobs:
         run: |
           pytest tests/test_death_data.py
         continue-on-error: false
+      - name: Run Python tests data generation utils
+        run: |
+          pytest tests/test_data_generation_utils.py
+        continue-on-error: false
       - name: Run doctests
         run: |
           TQDM_DISABLE=1 pytest leap/ --doctest-modules

--- a/leap/data_generation/utils.py
+++ b/leap/data_generation/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import datetime as dt
 import argparse
 import itertools
-from leap.utils import TimeDelta, date_range, PROVINCE_MAP
+from leap.utils import date_range, TimeDelta, Timepoint, PROVINCE_MAP
 from leap.logger import get_logger
 from typing import Optional, Tuple, List, Callable, Dict, Any, Literal
 
@@ -13,6 +13,8 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 # Most recent census date from StatCan; data switches from past to projected at this timepoint
 CENSUS_TIMEPOINT = dt.datetime(2021, 1, 1)
+
+SECONDS_PER_YEAR = 365.25 * 24 * 3600
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -118,6 +120,37 @@ def format_age_group(age_group: str, upper_age_group: str = "100 years and over"
         age = age.replace(" year", "")
         age = int(age)
     return age
+ 
+
+def convert_timepoint_to_numeric(timepoint: dt.datetime | Timepoint) -> float:
+    """Convert a datetime object to a numeric value.
+
+    Args:
+        timepoint: A datetime object.
+
+    Returns:
+        A number representing the year of the timepoint.
+    """
+    time_delta = timepoint - dt.datetime(1, 1, 1)
+    time_delta += dt.timedelta(days=366)  # Add 1 year to account for the fact that the first year is 1
+    return time_delta.total_seconds() / SECONDS_PER_YEAR
+
+
+def convert_numeric_to_timepoint(timepoint: float) -> Timepoint:
+    """Convert a numeric value to a datetime object.
+
+    Args:
+        timepoint: The number of years since the year 0.0 AD/BC.
+
+    Returns:
+        A Timepoint object representing the timepoint.
+    """
+    total_seconds = round(timepoint * SECONDS_PER_YEAR)
+    time_delta = dt.timedelta(seconds=total_seconds)
+
+    # Subtract 1 year to account for the fact that the first year is 1
+    timepoint_dt = dt.datetime(year=1, month=1, day=1) + time_delta - dt.timedelta(days=366)  
+    return Timepoint.from_datetime(timepoint_dt)
 
 
 def heaviside(x: float | list[float] | np.ndarray | pd.Series, threshold: float) -> int | list[int]:

--- a/tests/test_data_generation_utils.py
+++ b/tests/test_data_generation_utils.py
@@ -1,0 +1,31 @@
+    
+
+import pytest
+import datetime as dt
+from leap.data_generation.utils import convert_timepoint_to_numeric, convert_numeric_to_timepoint
+
+
+@pytest.mark.parametrize(
+    "timepoint, expected_value",
+    [
+        (dt.datetime(2024, 1, 1), 2023.958932238193),
+        (dt.datetime(2066, 12, 1), 2066.874743326489),
+        (dt.datetime(1, 1, 1), 1.002053388090349)
+    ]
+)
+def test_convert_timepoint_to_numeric(timepoint, expected_value):
+    result = convert_timepoint_to_numeric(timepoint)
+    assert result == expected_value
+
+
+@pytest.mark.parametrize(
+    "timepoint, expected_value",
+    [
+        (2023.958932238193, dt.datetime(2024, 1, 1)),
+        (2066.874743326489, dt.datetime(2066, 12, 1)),
+        (1.002053388090349, dt.datetime(1, 1, 1))
+    ]
+)
+def test_convert_numeric_to_timepoint(timepoint, expected_value):
+    result = convert_numeric_to_timepoint(timepoint)
+    assert result == expected_value


### PR DESCRIPTION
## Description

The `Timepoint`/`dt.datetime` classes are used frequently in the data generation process, and for things like GLMs, we need a way to convert this value to some sort of `float`. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [ ] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] `tests/test_data_generation_utils.py`: `test_convert_timepoint_to_numeric`
- [x] `tests/test_data_generation_utils.py`: `test_convert_numeric_to_timepoint`

## Linked PRs / Issues

List here any related pull requests (from this repo or other repos) and/or the issue this PR is addressing.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
